### PR TITLE
Add fellowship config file and quest improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,42 @@ Add this hook to `.claude/settings.local.json` in repos where you use fellowship
 
 Also add `tmp/` to your `.gitignore` — checkpoints are local ephemeral state.
 
+### Configuration (Optional)
+
+Create `.claude/fellowship.json` in your project root to customize fellowship behavior. All settings are optional — missing keys use sensible defaults that match the out-of-box behavior.
+
+```json
+{
+  "branchPrefix": "fellowship/",
+  "worktree": {
+    "enabled": true
+  },
+  "gates": {
+    "autoApprove": []
+  },
+  "pr": {
+    "draft": false,
+    "template": null
+  },
+  "palantir": {
+    "enabled": true,
+    "minQuests": 2
+  }
+}
+```
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `branchPrefix` | `"fellowship/"` | Prefix for worktree branch names. E.g., `"feature/"` produces `feature/{task-slug}`. |
+| `worktree.enabled` | `true` | Whether quests create isolated worktrees. Set to `false` to work on the current branch. |
+| `gates.autoApprove` | `[]` | Gate names to auto-approve: `"Research"`, `"Plan"`, `"Implement"`, `"Review"`, `"Complete"`. Gates not listed still surface to you for approval. |
+| `pr.draft` | `false` | Create PRs as drafts. |
+| `pr.template` | `null` | PR body template string. Supports `{task}`, `{summary}`, and `{changes}` placeholders. |
+| `palantir.enabled` | `true` | Whether to spawn a palantir monitoring agent during fellowships. |
+| `palantir.minQuests` | `2` | Minimum active quests before palantir is spawned. |
+
+The config is read at fellowship startup and quest onboard (Phase 0). Changes to the file take effect on the next fellowship or quest invocation.
+
 ## Skills
 
 | Skill | Purpose |
@@ -90,14 +126,14 @@ Phase 5: Complete   → PR creation + worktree cleanup
 
 **Multiple tasks** — run `/fellowship`:
 
-Gandalf (the coordinator) spawns quest-running teammates, each in an isolated worktree. All phase gates surface to you for approval — nothing auto-proceeds. Each quest produces a PR. Say "status" to see a progress table showing each quest's current phase with visual progress indicators.
+Gandalf (the coordinator) spawns quest-running teammates, each in an isolated worktree. By default, all phase gates surface to you for approval. You can auto-approve specific gates via `.claude/fellowship.json` (see Configuration). Each quest produces a PR. Say "status" to see a progress table showing each quest's current phase with visual progress indicators.
 
 ## Design Principles
 
 - **Context is the bottleneck.** Compact between every phase. Don't let research noise degrade implementation reasoning.
 - **Hard gates prevent drift.** No planning without understanding. No implementing without a plan. No PR without review.
 - **Compose, don't rebuild.** Skills call other skills. No new runtime code — just orchestration over Claude Code primitives.
-- **Human in the loop.** All gates require your approval. Gandalf doesn't auto-approve anything or merge PRs.
+- **Human in the loop.** By default, all gates require your approval. You can opt into auto-approval for specific gates via config. Gandalf never merges PRs.
 - **Isolation by default.** Every quest gets its own worktree. No shared in-progress state.
 - **Local scope only.** Teammates are restricted to code, tests, git, and the filesystem. MCP tools and external services (Notion, Slack, Jira, etc.) require explicit approval.
 

--- a/skills/council/SKILL.md
+++ b/skills/council/SKILL.md
@@ -37,6 +37,8 @@ Read the root CLAUDE.md. Extract:
 
 If no CLAUDE.md exists, note: "Consider running `/chronicle` to set up project context."
 
+Also check for `.claude/fellowship.json`. If it exists, read it and note any non-default settings. These will be included in the Session Context block under Architecture Notes so downstream skills (quest, lembas) are aware of the active configuration.
+
 ### Step 2: Understand the Task
 
 Ask one focused question:

--- a/skills/quest/SKILL.md
+++ b/skills/quest/SKILL.md
@@ -60,12 +60,13 @@ When running as a fellowship teammate (indicated by the spawn prompt), report ea
 
 ### Phase 0: Onboard
 
-1. **Isolate:** Invoke `superpowers:using-git-worktrees` to create an isolated worktree for this work. This keeps the main branch clean and allows safe experimentation.
-2. **Orient:** Invoke `/council` to load task-relevant context.
+1. **Config:** Read `.claude/fellowship.json` from the project root if it exists. Merge with defaults (see fellowship skill for the full schema). If the file does not exist, all defaults apply.
+2. **Isolate:** If `config.worktree.enabled` is true (default), invoke `superpowers:using-git-worktrees` to create an isolated worktree for this work. This keeps the main branch clean and allows safe experimentation. If `config.worktree.enabled` is false, work on the current branch without worktree isolation.
+3. **Orient:** Invoke `/council` to load task-relevant context.
 
 If the user has already described their task, pass the description directly. Otherwise, council will ask.
 
-**Gate:** Worktree created AND Session Context block must exist before proceeding.
+**Gate:** Isolation set up (worktree created or skipped per config) AND Session Context block must exist before proceeding.
 
 ### Phase 1: Research
 
@@ -165,6 +166,7 @@ Goal: Integrate the work — squash/merge, PR creation, worktree cleanup.
 1. Invoke `superpowers:finishing-a-development-branch` to present integration options
 2. This skill handles: squash vs merge decision, PR creation, branch cleanup
 3. If working in a worktree (from Phase 0), clean up the worktree after merge
+4. **PR config:** If `config.pr.draft` is true, create the PR as a draft. If `config.pr.template` is set (a string), use it as the PR body template — the template can contain `{task}`, `{summary}`, and `{changes}` placeholders that get filled in with the actual values.
 
 **Gate:** Phase 4 verification must have passed. Do not complete without a green verification step.
 


### PR DESCRIPTION
## Summary

- Add `.claude/fellowship.json` config file support for user-configurable settings (branch prefix, worktree strategy, gate auto-approval, PR defaults, palantir settings)
- All settings have sensible defaults matching current behavior — zero breaking changes when config is absent
- Config is read at fellowship startup and quest onboard (Phase 0)

### Config settings

| Setting | Default | Description |
|---------|---------|-------------|
| `branchPrefix` | `"fellowship/"` | Prefix for worktree branch names |
| `worktree.enabled` | `true` | Whether quests create isolated worktrees |
| `gates.autoApprove` | `[]` | Gate names to auto-approve without user interaction |
| `pr.draft` | `false` | Create PRs as drafts |
| `pr.template` | `null` | PR body template with placeholder support |
| `palantir.enabled` | `true` | Whether to spawn palantir monitoring agent |
| `palantir.minQuests` | `2` | Minimum quests before palantir spawns |

### Files changed

- `skills/fellowship/SKILL.md` — Config loading, configurable branch prefix, gate auto-approval, palantir config
- `skills/quest/SKILL.md` — Config reading at Phase 0, worktree toggle, PR config at Phase 5
- `skills/council/SKILL.md` — Config awareness in context loading
- `README.md` — Configuration documentation section

## Test plan

- [ ] Verify fellowship works without `.claude/fellowship.json` (all defaults apply)
- [ ] Create config with `branchPrefix: "feature/"` and verify branch naming
- [ ] Create config with `gates.autoApprove: ["Research", "Plan"]` and verify auto-approval
- [ ] Create config with `pr.draft: true` and verify draft PR creation
- [ ] Create config with `worktree.enabled: false` and verify no worktree creation

Generated with [Claude Code](https://claude.com/claude-code)