### PR TITLE
feat: add quest status tracking to dashboard

### DIFF
--- a/cli/cmd/fellowship/main.go
+++ b/cli/cmd/fellowship/main.go
@@ -147,6 +147,7 @@ Fellowship state:
     --worktree PATH       Worktree path
     --branch BRANCH       Branch name
     --task-id ID          Task ID
+    --status STATUS       Quest status (active, completed, cancelled)
   state show              Show fellowship state as JSON
     --dir PATH            Git repo root (default: auto-detect)
 
@@ -1147,10 +1148,16 @@ func runStateUpdateQuest(args []string) int {
 	worktree := fs.String("worktree", "", "Worktree path")
 	branch := fs.String("branch", "", "Branch name")
 	taskID := fs.String("task-id", "", "Task ID")
+	statusFlag := fs.String("status", "", "Quest status (active, completed, cancelled)")
 	fs.Parse(args)
 
 	if *name == "" {
-		fmt.Fprintln(os.Stderr, "usage: fellowship state update-quest --name <name> [--worktree PATH] [--branch BRANCH] [--task-id ID] [--dir PATH]")
+		fmt.Fprintln(os.Stderr, "usage: fellowship state update-quest --name <name> [--worktree PATH] [--branch BRANCH] [--task-id ID] [--status STATUS] [--dir PATH]")
+		return 1
+	}
+
+	if *statusFlag != "" && *statusFlag != "active" && *statusFlag != "completed" && *statusFlag != "cancelled" {
+		fmt.Fprintf(os.Stderr, "fellowship: invalid status %q (must be active, completed, or cancelled)\n", *statusFlag)
 		return 1
 	}
 
@@ -1167,6 +1174,9 @@ func runStateUpdateQuest(args []string) int {
 				}
 				if *taskID != "" {
 					s.Quests[i].TaskID = *taskID
+				}
+				if *statusFlag != "" {
+					s.Quests[i].Status = *statusFlag
 				}
 				return nil
 			}

--- a/cli/internal/dashboard/fellowship.go
+++ b/cli/internal/dashboard/fellowship.go
@@ -36,6 +36,16 @@ type QuestEntry struct {
 	Worktree        string `json:"worktree"`
 	Branch          string `json:"branch"`
 	TaskID          string `json:"task_id"`
+	Status          string `json:"status,omitempty"`
+}
+
+// QuestEntryStatus returns the effective status of a quest entry.
+// Returns q.Status if set, otherwise "active".
+func QuestEntryStatus(q QuestEntry) string {
+	if q.Status != "" {
+		return q.Status
+	}
+	return "active"
 }
 
 type ScoutEntry struct {
@@ -48,6 +58,7 @@ type QuestStatus struct {
 	Name            string  `json:"name"`
 	Worktree        string  `json:"worktree"`
 	Phase           string  `json:"phase"`
+	Status          string  `json:"status"`
 	GatePending     bool    `json:"gate_pending"`
 	GateID          *string `json:"gate_id"`
 	LembasCompleted bool    `json:"lembas_completed"`
@@ -92,9 +103,20 @@ func discoverFromFellowshipState(fs *FellowshipState) (*DashboardStatus, error) 
 	for _, q := range fs.Quests {
 		qs, err := loadQuestStatus(q.Name, q.Worktree)
 		if err != nil {
-			// Skip quests where state can't be loaded
+			// Worktree state can't be loaded — show completed/cancelled quests
+			// as synthetic entries, skip active quests with missing worktrees
+			entryStatus := QuestEntryStatus(q)
+			if entryStatus == "completed" || entryStatus == "cancelled" {
+				status.Quests = append(status.Quests, QuestStatus{
+					Name:     q.Name,
+					Worktree: q.Worktree,
+					Phase:    "Complete",
+					Status:   entryStatus,
+				})
+			}
 			continue
 		}
+		qs.Status = QuestEntryStatus(q)
 		status.Quests = append(status.Quests, *qs)
 	}
 	return status, nil

--- a/cli/internal/dashboard/fellowship_test.go
+++ b/cli/internal/dashboard/fellowship_test.go
@@ -284,3 +284,228 @@ func TestLoadFellowshipState_Missing(t *testing.T) {
 		t.Fatal("LoadFellowshipState() expected error for missing file, got nil")
 	}
 }
+
+func TestQuestEntryStatus_Default(t *testing.T) {
+	q := QuestEntry{Name: "test"}
+	if got := QuestEntryStatus(q); got != "active" {
+		t.Errorf("QuestEntryStatus() = %q, want %q", got, "active")
+	}
+}
+
+func TestQuestEntryStatus_Explicit(t *testing.T) {
+	for _, status := range []string{"active", "completed", "cancelled"} {
+		q := QuestEntry{Name: "test", Status: status}
+		if got := QuestEntryStatus(q); got != status {
+			t.Errorf("QuestEntryStatus(%q) = %q, want %q", status, got, status)
+		}
+	}
+}
+
+func TestSaveFellowshipState_WithStatus(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "fellowship-state.json")
+
+	original := &FellowshipState{
+		Version: 1, Name: "test", CreatedAt: "2025-01-15T10:30:00Z",
+		Quests: []QuestEntry{
+			{Name: "q1", Status: "completed"},
+			{Name: "q2"}, // no status — omitempty
+		},
+	}
+
+	if err := SaveFellowshipState(path, original); err != nil {
+		t.Fatalf("SaveFellowshipState() error: %v", err)
+	}
+
+	loaded, err := LoadFellowshipState(path)
+	if err != nil {
+		t.Fatalf("LoadFellowshipState() error: %v", err)
+	}
+
+	if loaded.Quests[0].Status != "completed" {
+		t.Errorf("Quests[0].Status = %q, want %q", loaded.Quests[0].Status, "completed")
+	}
+	if loaded.Quests[1].Status != "" {
+		t.Errorf("Quests[1].Status = %q, want empty", loaded.Quests[1].Status)
+	}
+}
+
+func TestDiscoverQuests_CompletedMissingWorktree(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+
+	if err := os.MkdirAll(filepath.Join(root, ".fellowship"), 0755); err != nil {
+		t.Fatalf("creating data dir: %v", err)
+	}
+	fellowshipState := `{
+  "name": "test-fellowship",
+  "created_at": "2025-01-15T10:30:00Z",
+  "quests": [
+    {
+      "name": "quest-done",
+      "worktree": "/nonexistent/worktree",
+      "task_id": "t1",
+      "status": "completed"
+    }
+  ],
+  "scouts": []
+}`
+	if err := os.WriteFile(filepath.Join(root, ".fellowship", "fellowship-state.json"), []byte(fellowshipState), 0644); err != nil {
+		t.Fatalf("writing fellowship-state.json: %v", err)
+	}
+
+	status, err := DiscoverQuests(root)
+	if err != nil {
+		t.Fatalf("DiscoverQuests() error: %v", err)
+	}
+
+	if len(status.Quests) != 1 {
+		t.Fatalf("len(Quests) = %d, want 1", len(status.Quests))
+	}
+	q := status.Quests[0]
+	if q.Name != "quest-done" {
+		t.Errorf("Quest.Name = %q, want %q", q.Name, "quest-done")
+	}
+	if q.Phase != "Complete" {
+		t.Errorf("Quest.Phase = %q, want %q", q.Phase, "Complete")
+	}
+	if q.Status != "completed" {
+		t.Errorf("Quest.Status = %q, want %q", q.Status, "completed")
+	}
+}
+
+func TestDiscoverQuests_CancelledMissingWorktree(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+
+	if err := os.MkdirAll(filepath.Join(root, ".fellowship"), 0755); err != nil {
+		t.Fatalf("creating data dir: %v", err)
+	}
+	fellowshipState := `{
+  "name": "test-fellowship",
+  "created_at": "2025-01-15T10:30:00Z",
+  "quests": [
+    {
+      "name": "quest-cancelled",
+      "worktree": "/nonexistent/worktree",
+      "task_id": "t1",
+      "status": "cancelled"
+    }
+  ],
+  "scouts": []
+}`
+	if err := os.WriteFile(filepath.Join(root, ".fellowship", "fellowship-state.json"), []byte(fellowshipState), 0644); err != nil {
+		t.Fatalf("writing fellowship-state.json: %v", err)
+	}
+
+	status, err := DiscoverQuests(root)
+	if err != nil {
+		t.Fatalf("DiscoverQuests() error: %v", err)
+	}
+
+	if len(status.Quests) != 1 {
+		t.Fatalf("len(Quests) = %d, want 1", len(status.Quests))
+	}
+	if status.Quests[0].Status != "cancelled" {
+		t.Errorf("Quest.Status = %q, want %q", status.Quests[0].Status, "cancelled")
+	}
+	if status.Quests[0].Phase != "Complete" {
+		t.Errorf("Quest.Phase = %q, want %q", status.Quests[0].Phase, "Complete")
+	}
+}
+
+func TestDiscoverQuests_ActiveMissingWorktreeSkipped(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+
+	if err := os.MkdirAll(filepath.Join(root, ".fellowship"), 0755); err != nil {
+		t.Fatalf("creating data dir: %v", err)
+	}
+	// Active quest (no status) with missing worktree — should still be skipped
+	fellowshipState := `{
+  "name": "test-fellowship",
+  "created_at": "2025-01-15T10:30:00Z",
+  "quests": [
+    {
+      "name": "quest-active",
+      "worktree": "/nonexistent/worktree",
+      "task_id": "t1"
+    }
+  ],
+  "scouts": []
+}`
+	if err := os.WriteFile(filepath.Join(root, ".fellowship", "fellowship-state.json"), []byte(fellowshipState), 0644); err != nil {
+		t.Fatalf("writing fellowship-state.json: %v", err)
+	}
+
+	status, err := DiscoverQuests(root)
+	if err != nil {
+		t.Fatalf("DiscoverQuests() error: %v", err)
+	}
+
+	if len(status.Quests) != 0 {
+		t.Errorf("len(Quests) = %d, want 0 (active quest with missing worktree should be skipped)", len(status.Quests))
+	}
+}
+
+func TestDiscoverQuests_CompletedExistingWorktree(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+
+	// Create a worktree with quest-state.json
+	worktreeDir := filepath.Join(root, "worktrees", "quest-done")
+	if err := os.MkdirAll(filepath.Join(worktreeDir, ".fellowship"), 0755); err != nil {
+		t.Fatalf("creating worktree dir: %v", err)
+	}
+	questState := `{
+  "version": 1,
+  "quest_name": "quest-done",
+  "task_id": "t1",
+  "team_name": "team",
+  "phase": "Complete",
+  "gate_pending": false,
+  "gate_id": null,
+  "lembas_completed": false,
+  "metadata_updated": false,
+  "auto_approve_gates": []
+}`
+	if err := os.WriteFile(filepath.Join(worktreeDir, ".fellowship", "quest-state.json"), []byte(questState), 0644); err != nil {
+		t.Fatalf("writing quest-state.json: %v", err)
+	}
+
+	if err := os.MkdirAll(filepath.Join(root, ".fellowship"), 0755); err != nil {
+		t.Fatalf("creating data dir: %v", err)
+	}
+	fellowshipState := fmt.Sprintf(`{
+  "name": "test-fellowship",
+  "created_at": "2025-01-15T10:30:00Z",
+  "quests": [
+    {
+      "name": "quest-done",
+      "worktree": %q,
+      "task_id": "t1",
+      "status": "completed"
+    }
+  ],
+  "scouts": []
+}`, worktreeDir)
+	if err := os.WriteFile(filepath.Join(root, ".fellowship", "fellowship-state.json"), []byte(fellowshipState), 0644); err != nil {
+		t.Fatalf("writing fellowship-state.json: %v", err)
+	}
+
+	status, err := DiscoverQuests(root)
+	if err != nil {
+		t.Fatalf("DiscoverQuests() error: %v", err)
+	}
+
+	if len(status.Quests) != 1 {
+		t.Fatalf("len(Quests) = %d, want 1", len(status.Quests))
+	}
+	q := status.Quests[0]
+	if q.Status != "completed" {
+		t.Errorf("Quest.Status = %q, want %q", q.Status, "completed")
+	}
+	if q.Phase != "Complete" {
+		t.Errorf("Quest.Phase = %q, want %q", q.Phase, "Complete")
+	}
+}

--- a/cli/internal/dashboard/static/app.js
+++ b/cli/internal/dashboard/static/app.js
@@ -65,7 +65,13 @@
 
     const quests = status.quests || [];
     const scouts = status.scouts || [];
-    document.getElementById("quest-count").textContent = quests.length + " quest" + (quests.length !== 1 ? "s" : "");
+    var activeQuests = quests.filter(function (q) { return q.status !== "completed" && q.status !== "cancelled"; });
+    var doneQuests = quests.filter(function (q) { return q.status === "completed" || q.status === "cancelled"; });
+    var questCountText = quests.length + " quest" + (quests.length !== 1 ? "s" : "");
+    if (doneQuests.length > 0) {
+      questCountText += " (" + doneQuests.length + " done)";
+    }
+    document.getElementById("quest-count").textContent = questCountText;
     document.getElementById("scout-count").textContent = scouts.length + " scout" + (scouts.length !== 1 ? "s" : "");
 
     // Quest cards — group by company
@@ -75,7 +81,7 @@
     var rendered = {};
 
     companies.forEach(function (c) {
-      var companyQuests = quests.filter(function (q) {
+      var companyQuests = activeQuests.filter(function (q) {
         return c.quests && c.quests.indexOf(q.name) !== -1;
       });
       var companyScouts = scouts.filter(function (s) {
@@ -95,8 +101,8 @@
       });
     });
 
-    // Ungrouped quests and scouts
-    var ungroupedQuests = quests.filter(function (q) { return !rendered[q.name]; });
+    // Ungrouped active quests and scouts
+    var ungroupedQuests = activeQuests.filter(function (q) { return !rendered[q.name]; });
     var ungroupedScouts = scouts.filter(function (s) { return !rendered[s.name]; });
     if (ungroupedQuests.length > 0 || ungroupedScouts.length > 0) {
       if (companies.length > 0) {
@@ -111,6 +117,34 @@
       ungroupedScouts.forEach(function (s) {
         container.appendChild(renderScoutCard(s));
       });
+    }
+
+    // Done quests section
+    if (doneQuests.length > 0) {
+      var doneSection = document.createElement("div");
+      doneSection.className = "done-section";
+
+      var doneHeader = document.createElement("div");
+      doneHeader.className = "done-section-header";
+      doneHeader.innerHTML = "<h2>Done</h2>" +
+        '<span class="done-count">' + doneQuests.length + " quest" + (doneQuests.length !== 1 ? "s" : "") + "</span>";
+      doneHeader.style.cursor = "pointer";
+
+      var doneCards = document.createElement("div");
+      doneCards.className = "done-cards";
+
+      doneQuests.forEach(function (q) {
+        doneCards.appendChild(renderCard(q));
+      });
+
+      doneHeader.addEventListener("click", function () {
+        doneCards.classList.toggle("collapsed");
+        doneHeader.classList.toggle("collapsed");
+      });
+
+      doneSection.appendChild(doneHeader);
+      doneSection.appendChild(doneCards);
+      container.appendChild(doneSection);
     }
 
     prevStatus = status;
@@ -149,7 +183,8 @@
 
   function renderCard(quest) {
     const card = document.createElement("div");
-    card.className = "quest-card" + (quest.gate_pending ? " pending" : "");
+    var isDone = quest.status === "completed" || quest.status === "cancelled";
+    card.className = "quest-card" + (quest.gate_pending ? " pending" : "") + (isDone ? " " + quest.status : "");
 
     const phaseIndex = PHASES.indexOf(quest.phase);
 
@@ -163,6 +198,13 @@
     var eaglesHealth = getQuestHealth(quest.worktree);
     var badgeHTML = eaglesHealth ? " " + renderHealthBadge(eaglesHealth.health) : "";
 
+    var statusBadgeHTML = "";
+    if (isDone) {
+      var statusLabel = quest.status === "completed" ? "completed" : "cancelled";
+      var statusClass = quest.status === "completed" ? "status-done" : "status-blocked";
+      statusBadgeHTML = ' <span class="status-badge ' + statusClass + '">' + escapeHTML(statusLabel) + "</span>";
+    }
+
     var errandProgressHTML = "";
     if (quest.errands_total > 0) {
       errandProgressHTML = '<div class="errand-progress">' +
@@ -171,7 +213,7 @@
     }
 
     card.innerHTML =
-      "<h3>" + escapeHTML(quest.name || quest.worktree) + badgeHTML + "</h3>" +
+      "<h3>" + escapeHTML(quest.name || quest.worktree) + badgeHTML + statusBadgeHTML + "</h3>" +
       '<div class="quest-phase">' + escapeHTML(quest.phase || "Unknown") + "</div>" +
       progressHTML +
       errandProgressHTML;

--- a/cli/internal/dashboard/static/style.css
+++ b/cli/internal/dashboard/static/style.css
@@ -223,6 +223,72 @@ main {
     color: var(--text-secondary);
 }
 
+/* ── Done Quests ───────────────────────────────── */
+
+.quest-card.completed {
+    opacity: 0.6;
+    border-color: var(--green);
+}
+
+.quest-card.completed .progress-segment.filled {
+    background: var(--green);
+}
+
+.quest-card.cancelled {
+    opacity: 0.6;
+    border-color: #4a4a4a;
+}
+
+.quest-card.cancelled .progress-segment.filled {
+    background: #6a6a6a;
+}
+
+.done-section {
+    margin-top: 1.5rem;
+}
+
+.done-section-header {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.5rem 0;
+    border-bottom: 1px solid #3a3028;
+    margin-bottom: 0.75rem;
+}
+
+.done-section-header h2 {
+    font-family: var(--font-heading);
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--text-secondary);
+    letter-spacing: 0.06em;
+}
+
+.done-section-header::before {
+    content: "▾";
+    color: var(--text-secondary);
+    font-size: 0.8rem;
+}
+
+.done-section-header.collapsed::before {
+    content: "▸";
+}
+
+.done-count {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+}
+
+.done-cards {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.done-cards.collapsed {
+    display: none;
+}
+
 /* ── Errands ───────────────────────────────────── */
 
 .errand-progress {


### PR DESCRIPTION
## Summary
- Add `Status` field to `QuestEntry` (with `omitempty` for backward compat) and `QuestStatus` structs
- Completed/cancelled quests with missing worktrees now appear as synthetic entries instead of vanishing
- Add `--status` flag to `state update-quest` CLI with validation (active/completed/cancelled)
- Frontend splits quests into active vs collapsible "Done" section with muted styling and status badges
- Header shows "3 quests (1 done)" style count

Closes #31

## Test plan
- [x] `go test ./internal/dashboard/...` — 7 new tests all pass
- [x] `go build ./...` succeeds
- [ ] Manual: create fellowship-state.json with completed quest + missing worktree, run dashboard, confirm it appears dimmed in Done section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now mark quests as completed or cancelled via status flag.
  * Dashboard displays completed and cancelled quests in a dedicated "Done" section with count.
  * Added status badges to visually distinguish quest completion states.

* **Style**
  * Enhanced visual styling: green borders for completed quests, gray for cancelled.
  * Done section is collapsible for improved dashboard organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->