### PR TITLE
fix: resolve fellowship startup issues

### DIFF
--- a/cli/cmd/fellowship/main.go
+++ b/cli/cmd/fellowship/main.go
@@ -1179,9 +1179,13 @@ func runStateInit(args []string) int {
 	}
 	statePath := filepath.Join(dataDirPath, "fellowship-state.json")
 
-	if existing, err := dashboard.LoadFellowshipState(statePath); err == nil {
-		fmt.Fprintf(os.Stderr, "fellowship: warning: overwriting existing fellowship-state.json (name=%q, quests=%d)\n",
-			existing.Name, len(existing.Quests))
+	if _, err := os.Stat(statePath); err == nil {
+		if existing, loadErr := dashboard.LoadFellowshipState(statePath); loadErr == nil {
+			fmt.Fprintf(os.Stderr, "fellowship: warning: overwriting existing fellowship-state.json (name=%q, quests=%d)\n",
+				existing.Name, len(existing.Quests))
+		} else {
+			fmt.Fprintln(os.Stderr, "fellowship: warning: overwriting existing fellowship-state.json")
+		}
 	}
 
 	s := &dashboard.FellowshipState{

--- a/plugin/skills/fellowship/SKILL.md
+++ b/plugin/skills/fellowship/SKILL.md
@@ -23,10 +23,11 @@ Coordinates parallel teammates — quest runners and scouts — using the agent 
 Before doing anything else, run `ensure-binary.sh` to guarantee the CLI binary is installed and up to date (it is idempotent — no-ops if the correct version is already present):
 
 ```bash
-~/.claude/plugins/cache/justinjdev/fellowship/*/plugin/hooks/scripts/ensure-binary.sh
+latest_plugin_dir="$(ls -dt ~/.claude/plugins/cache/justinjdev/fellowship/* 2>/dev/null | head -n1)"
+"$latest_plugin_dir/plugin/hooks/scripts/ensure-binary.sh"
 ```
 
-The glob `*` matches the installed version. After this runs, the binary is at `~/.claude/fellowship/bin/fellowship`. Use that full path for all CLI calls in this session — do not rely on `fellowship` being in PATH.
+This resolves the most-recently-installed version directory, avoiding ambiguity if multiple cached versions exist. After this runs, the binary is at `~/.claude/fellowship/bin/fellowship`. Use that full path for all CLI calls in this session — do not rely on `fellowship` being in PATH.
 
 If `ensure-binary.sh` fails, stop and tell the user:
 


### PR DESCRIPTION
## Summary

- **CLI not in PATH**: Skill now runs `ensure-binary.sh` at startup (idempotent) and uses `~/.claude/fellowship/bin/fellowship` for all CLI calls — no PATH dependency
- **Stale state file**: `state init` now overwrites existing state silently instead of erroring
- **Deprecated subcommands**: Remove `install`/`uninstall` from CLI and skill (hooks are plugin-provided; these were no-ops)

## Test plan

- [ ] Run `/fellowship` in a repo where `fellowship` is not in PATH — should auto-install and proceed
- [ ] Run `fellowship state init` twice in the same dir — should succeed both times
- [ ] Verify `fellowship install` and `fellowship uninstall` are no longer recognized subcommands

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Removed the install and uninstall commands from the CLI.
  * CLI state initialization now loads an existing state with a warning and allows overwrite instead of failing.

* **Documentation**
  * Added "Ensure CLI" instructions to run the installer and require full CLI binary path for all invocations; notes idempotency and halting on failure.
  * Updated Disband workflow to remove the uninstall step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->