### PR TITLE
fix: prevent lead hook blocking and quest CWD mismatch

### DIFF
--- a/cli/cmd/fellowship/main.go
+++ b/cli/cmd/fellowship/main.go
@@ -114,6 +114,7 @@ Agent/lead commands:
 
 Setup commands:
   init                   Create quest-state.json in data directory
+    --dir PATH           Worktree or repo root (default: auto-detect via git)
     --phase PHASE        Initial phase (default: Onboard)
     --plan-skip          Record Onboard/Research/Plan as skipped in tome
     --quest NAME         Quest name for tome recording
@@ -537,6 +538,7 @@ func runInit() int {
 	phase := fs.String("phase", "", "Initial phase (default: Onboard)")
 	planSkip := fs.Bool("plan-skip", false, "Record Onboard/Research/Plan as skipped in tome")
 	questName := fs.String("quest", "", "Quest name for tome recording")
+	initDir := fs.String("dir", "", "Worktree or repo root (default: auto-detect via git)")
 	fs.Parse(os.Args[2:])
 
 	validPhases := map[string]bool{
@@ -556,13 +558,16 @@ func runInit() int {
 		return 1
 	}
 
-	root := gitRootOrCwd()
-	dir := filepath.Join(root, datadir.Name())
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	root := *initDir
+	if root == "" {
+		root = gitRootOrCwd()
+	}
+	dataDir := filepath.Join(root, datadir.Name())
+	if err := os.MkdirAll(dataDir, 0755); err != nil {
 		fmt.Fprintf(os.Stderr, "fellowship: creating data directory: %v\n", err)
 		return 1
 	}
-	path := filepath.Join(dir, "quest-state.json")
+	path := filepath.Join(dataDir, "quest-state.json")
 
 	if _, err := os.Stat(path); err == nil {
 		s, err := state.Load(path)
@@ -600,7 +605,7 @@ func runInit() int {
 	}
 
 	if *planSkip {
-		tomePath := filepath.Join(dir, "quest-tome.json")
+		tomePath := filepath.Join(dataDir, "quest-tome.json")
 		c := tome.LoadOrCreate(tomePath)
 		if *questName != "" {
 			c.QuestName = *questName

--- a/cli/internal/state/state.go
+++ b/cli/internal/state/state.go
@@ -118,8 +118,16 @@ func FindStateFile(fromDir string) (string, error) {
 	if err != nil {
 		root = fromDir
 	}
-	path := filepath.Join(root, datadir.Name(), "quest-state.json")
+	dd := filepath.Join(root, datadir.Name())
+	path := filepath.Join(dd, "quest-state.json")
 	if _, err := os.Stat(path); err != nil {
+		return "", nil
+	}
+	// If fellowship-state.json also exists in this data directory, the CWD is
+	// at the main repo root where the lead (Gandalf) runs — not inside a quest
+	// worktree. Skip quest-state enforcement so the lead isn't blocked by a
+	// quest runner's state file that leaked into the repo root.
+	if _, err := os.Stat(filepath.Join(dd, "fellowship-state.json")); err == nil {
 		return "", nil
 	}
 	return path, nil

--- a/cli/internal/state/state_test.go
+++ b/cli/internal/state/state_test.go
@@ -139,3 +139,43 @@ func TestFindStateFile_NoFile(t *testing.T) {
 		t.Errorf("expected empty path, got %q", path)
 	}
 }
+
+func TestFindStateFile_SkipsWhenFellowshipStateExists(t *testing.T) {
+	// Simulate the main repo root where both quest-state.json and
+	// fellowship-state.json exist (lead's CWD). The hook should NOT
+	// find the quest-state file so the lead isn't blocked.
+	t.Setenv("HOME", t.TempDir())
+	dir := t.TempDir()
+	dd := filepath.Join(dir, ".fellowship")
+	os.MkdirAll(dd, 0755)
+	os.WriteFile(filepath.Join(dd, "quest-state.json"), []byte(validState), 0644)
+	os.WriteFile(filepath.Join(dd, "fellowship-state.json"), []byte(`{"version":1}`), 0644)
+
+	// FindStateFile uses gitRoot which won't work in a temp dir, so it
+	// falls back to fromDir. With both files present it should return "".
+	path, err := FindStateFile(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if path != "" {
+		t.Errorf("expected empty path when fellowship-state.json exists, got %q", path)
+	}
+}
+
+func TestFindStateFile_ReturnsPathWhenOnlyQuestState(t *testing.T) {
+	// Simulate a quest worktree where only quest-state.json exists.
+	t.Setenv("HOME", t.TempDir())
+	dir := t.TempDir()
+	dd := filepath.Join(dir, ".fellowship")
+	os.MkdirAll(dd, 0755)
+	os.WriteFile(filepath.Join(dd, "quest-state.json"), []byte(validState), 0644)
+
+	path, err := FindStateFile(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := filepath.Join(dd, "quest-state.json")
+	if path != expected {
+		t.Errorf("got %q, want %q", path, expected)
+	}
+}

--- a/plugin/skills/fellowship/resources/lead-behavior.md
+++ b/plugin/skills/fellowship/resources/lead-behavior.md
@@ -119,10 +119,19 @@ When the user explicitly requests promotion (e.g., "promote scout-auth findings 
 
 Never combine gate approvals. Approve one gate at a time. Each gate response triggers exactly one transition — never tell a teammate to skip ahead through multiple gates. When a teammate sends a gate message, surface it (or auto-approve per config), then wait for the next gate to arrive before acting on it.
 
+## CWD Discipline
+
+**Never `cd` into a quest worktree.** Gandalf must stay at the repo root for the entire fellowship session. If you `cd` into a worktree, the gate-guard hooks will find that quest's state file and block your tools — creating a deadlock where you can't approve gates or take any action.
+
+- Use `--dir <worktree_path>` flags for all fellowship CLI commands (e.g., `fellowship gate approve --dir <path>`)
+- Use absolute paths when reading files from quest worktrees
+- If you need to inspect a quest's files, use the Read tool with absolute paths — never `cd` first
+
 ## What Gandalf does NOT do
 
 - Write code
 - Run quests itself
+- Change into quest worktree directories
 - Make architectural decisions
 - Merge PRs (user's responsibility)
 - Skip or combine gate approvals

--- a/plugin/skills/quest/SKILL.md
+++ b/plugin/skills/quest/SKILL.md
@@ -90,7 +90,7 @@ When running as a fellowship teammate, a state file at `.fellowship/quest-state.
 If the spawn prompt contains a `RESUME CONTEXT:` block, this is a recovered quest:
 
 1. **Skip worktree creation** — your worktree already exists and you're already in it
-2. **Reset state file:** Run `fellowship init` to clear `gate_pending` while preserving the current phase
+2. **Reset state file:** Run `fellowship init --dir <worktree_path>` to clear `gate_pending` while preserving the current phase
 4. **Update task metadata:** `TaskUpdate(taskId: "<task_id>", metadata: {"worktree_path": "<cwd>"})` with the new task ID from the recovery spawn
 5. **Load checkpoint:** If `.fellowship/checkpoint.md` exists, read it as your initial context — this replaces `/council` orientation
 6. **Skip `/council`** — the checkpoint provides equivalent context from the previous session
@@ -113,11 +113,12 @@ After resume setup, proceed to the gate for Phase 0 as normal (run /lembas, upda
      - `{slug}`: slugify the task description (lowercase, hyphens for spaces, strip non-alphanumeric). If a ticket was extracted, derive slug from the remaining text after extraction.
      - `{ticket}`: match `branch.ticketPattern` (default: `[A-Z]+-\d+`) against the task description. If matched, use the match. If not matched and the pattern contains `{ticket}`, ask the user to provide a ticket ID.
      - `{author}`: use `branch.author` from config. If not set and the pattern contains `{author}`, ask the user to provide their name.
-   - **Create worktree (3-step sequence — all steps are REQUIRED):**
+   - **Create worktree (4-step sequence — all steps are REQUIRED):**
      1. Determine the base ref: if the spawn prompt includes `Base branch:` in the CONTEXT section, use `git rev-parse <base_branch>` to get the SHA; otherwise run `git rev-parse HEAD`. Save the full SHA in your response text (not a shell variable — shell state does not persist between tool calls).
      2. Call `EnterWorktree` with the resolved branch name. If `config.worktree.directory` is set, create the worktree there instead of the default location.
      3. **Immediately** after entering the worktree — before ANY other action — run `git reset --hard <sha>` using the exact SHA from step 1. `EnterWorktree` bases off the default branch, not the current branch. This reset is what makes the worktree start from the correct point. Skip this and the worktree will be wrong.
-3. **State file (fellowship only):** This MUST happen before any other tool calls (Skill, Bash, etc.) so that hooks can enforce gates from the start. If running as a fellowship teammate:
+     4. **Verify CWD:** Run `pwd` and confirm the output contains your branch name or expected worktree path. When multiple quests spawn in parallel, a race condition can place your CWD in another quest's worktree. If `pwd` shows a different quest's worktree, run `cd <expected_worktree_path>` to correct it before proceeding. The expected path is the one printed by `EnterWorktree` (typically `.claude/worktrees/<branch_name>/`).
+3. **State file (fellowship only):** This MUST happen before any other tool calls (Skill, Bash, etc.) so that hooks can enforce gates from the start. Run `fellowship init --dir <worktree_path>` (using the verified worktree path from step 2.4) to ensure the state file is created in the correct worktree, regardless of CWD. If running as a fellowship teammate:
    - If `.fellowship/quest-state.json` already exists (respawn), reset `gate_pending` to `false` and preserve the existing `phase`.
    - Otherwise, create `.fellowship/quest-state.json`:
      ```json
@@ -151,7 +152,7 @@ If the spawn prompt contains `PRE-EXISTING PLAN:` with a plan file path:
 
 1. **Create worktree** as normal (follow the full 3-step sequence from Standard Onboard, including the immediate `git reset --hard <sha>` after `EnterWorktree`)
 2. **Copy plan file:** Read the plan file from the specified path and write it to `.fellowship/plan.md` in the worktree
-3. **Initialize state at Implement:** Run `fellowship init --phase Implement --plan-skip --quest <quest_name>` — this creates the state file starting at Implement and records Onboard/Research/Plan as skipped in the tome
+3. **Initialize state at Implement:** Run `fellowship init --dir <worktree_path> --phase Implement --plan-skip --quest <quest_name>` — this creates the state file starting at Implement and records Onboard/Research/Plan as skipped in the tome
 4. **Initialize errands:** Run `fellowship errand init` to create the errand file, then add one errand per plan task with `fellowship errand add`
 5. **Skip /council** — the plan provides sufficient context
 6. **Proceed directly to Phase 3 (Implement)** — skip the Onboard gate, Research, and Plan entirely

--- a/plugin/skills/quest/SKILL.md
+++ b/plugin/skills/quest/SKILL.md
@@ -90,7 +90,7 @@ When running as a fellowship teammate, a state file at `.fellowship/quest-state.
 If the spawn prompt contains a `RESUME CONTEXT:` block, this is a recovered quest:
 
 1. **Skip worktree creation** — your worktree already exists and you're already in it
-2. **Reset state file:** Run `fellowship init --dir <worktree_path>` to clear `gate_pending` while preserving the current phase
+2. **Reset state file:** Run `fellowship init --dir $(pwd)` (you're already in the worktree) to clear `gate_pending` while preserving the current phase
 4. **Update task metadata:** `TaskUpdate(taskId: "<task_id>", metadata: {"worktree_path": "<cwd>"})` with the new task ID from the recovery spawn
 5. **Load checkpoint:** If `.fellowship/checkpoint.md` exists, read it as your initial context — this replaces `/council` orientation
 6. **Skip `/council`** — the checkpoint provides equivalent context from the previous session
@@ -118,7 +118,7 @@ After resume setup, proceed to the gate for Phase 0 as normal (run /lembas, upda
      2. Call `EnterWorktree` with the resolved branch name. If `config.worktree.directory` is set, create the worktree there instead of the default location.
      3. **Immediately** after entering the worktree — before ANY other action — run `git reset --hard <sha>` using the exact SHA from step 1. `EnterWorktree` bases off the default branch, not the current branch. This reset is what makes the worktree start from the correct point. Skip this and the worktree will be wrong.
      4. **Verify CWD:** Run `pwd` and confirm the output contains your branch name or expected worktree path. When multiple quests spawn in parallel, a race condition can place your CWD in another quest's worktree. If `pwd` shows a different quest's worktree, run `cd <expected_worktree_path>` to correct it before proceeding. The expected path is the one printed by `EnterWorktree` (typically `.claude/worktrees/<branch_name>/`).
-3. **State file (fellowship only):** This MUST happen before any other tool calls (Skill, Bash, etc.) so that hooks can enforce gates from the start. Run `fellowship init --dir <worktree_path>` (using the verified worktree path from step 2.4) to ensure the state file is created in the correct worktree, regardless of CWD. If running as a fellowship teammate:
+3. **State file (fellowship only):** This MUST happen before any other tool calls (Skill, Bash, etc.) so that hooks can enforce gates from the start. Run `fellowship init --dir <worktree_path>` (using the path from `EnterWorktree` in step 2.2, verified correct in step 2.4) to ensure the state file is created in the correct worktree, regardless of CWD. If running as a fellowship teammate:
    - If `.fellowship/quest-state.json` already exists (respawn), reset `gate_pending` to `false` and preserve the existing `phase`.
    - Otherwise, create `.fellowship/quest-state.json`:
      ```json

--- a/plugin/skills/quest/SKILL.md
+++ b/plugin/skills/quest/SKILL.md
@@ -150,7 +150,7 @@ If the user has already described their task, pass the description directly. Oth
 
 If the spawn prompt contains `PRE-EXISTING PLAN:` with a plan file path:
 
-1. **Create worktree** as normal (follow the full 3-step sequence from Standard Onboard, including the immediate `git reset --hard <sha>` after `EnterWorktree`)
+1. **Create worktree** as normal (follow the full 4-step sequence from Standard Onboard, including the immediate `git reset --hard <sha>` and CWD verification after `EnterWorktree`)
 2. **Copy plan file:** Read the plan file from the specified path and write it to `.fellowship/plan.md` in the worktree
 3. **Initialize state at Implement:** Run `fellowship init --dir <worktree_path> --phase Implement --plan-skip --quest <quest_name>` — this creates the state file starting at Implement and records Onboard/Research/Plan as skipped in the tome
 4. **Initialize errands:** Run `fellowship errand init` to create the errand file, then add one errand per plan task with `fellowship errand add`


### PR DESCRIPTION
## Summary

- **Lead protection (#72):** `FindStateFile` now returns empty when `fellowship-state.json` co-exists with `quest-state.json`, preventing the lead session from being blocked by a quest runner's state file
- **Explicit init path (#68):** `fellowship init` gains `--dir` flag so quest runners target their worktree explicitly instead of relying on CWD-based resolution
- **CWD verification (#68):** Quest Phase 0 adds a `pwd` check after `EnterWorktree` to detect and correct parallel-spawn race conditions

Closes #68, closes #72

## Test plan

- [x] New unit tests for `FindStateFile` lead-skip logic
- [x] All existing Go tests pass
- [ ] Manual: start a fellowship with 2+ quests, verify each quest's CWD is correct
- [ ] Manual: verify lead session is not blocked when a quest has `gate_pending: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --dir flag to fellowship init for explicitly specifying the work root.

* **Behavior Changes / Bug Fix**
  * State resolution now prefers a fellowship-level state file when present, skipping legacy quest-state detection under that repository.
  * State files are created/read relative to the specified workroot.

* **Documentation**
  * Updated workflows and lead behavior to require/advise using --dir and verify current worktree.
  
* **Tests**
  * Added tests covering state-resolution behavior with and without a fellowship-level state file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->