### PR TITLE
feat: quest autopsy — failure memory across sessions

### DIFF
--- a/cli/cmd/fellowship/main.go
+++ b/cli/cmd/fellowship/main.go
@@ -827,7 +827,7 @@ func runAutopsyScan(args []string) int {
 		opts.Tags = strings.Split(*tags, ",")
 	}
 
-	expiryDays := autopsy.ReadExpiryDays()
+	expiryDays := datadir.AutopsyExpiryDays(autopsy.DefaultExpiryDays)
 	matches, err := autopsy.Scan(root, opts, expiryDays)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "fellowship: %v\n", err)

--- a/cli/cmd/fellowship/main.go
+++ b/cli/cmd/fellowship/main.go
@@ -13,6 +13,7 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/justinjdev/fellowship/cli/internal/autopsy"
 	"github.com/justinjdev/fellowship/cli/internal/datadir"
 	"github.com/justinjdev/fellowship/cli/internal/company"
 	"github.com/justinjdev/fellowship/cli/internal/dashboard"
@@ -73,6 +74,12 @@ func main() {
 		os.Exit(runHold(os.Args[2:]))
 	case "unhold":
 		os.Exit(runUnhold(os.Args[2:]))
+	case "autopsy":
+		if len(os.Args) < 3 {
+			fmt.Fprintln(os.Stderr, "usage: fellowship autopsy <create|scan|infer>")
+			os.Exit(1)
+		}
+		os.Exit(runAutopsy(os.Args[2:]))
 	case "herald":
 		os.Exit(runHerald(os.Args[2:]))
 	case "dashboard":
@@ -188,6 +195,18 @@ Dashboard:
   dashboard              Start live web dashboard
     --port N             HTTP port (default: 3000)
     --poll N             Poll interval in seconds (default: 5)
+
+Autopsy (failure memory):
+  autopsy create         Write a structured failure record (reads JSON from stdin)
+    --dir DIR            Git repo root (default: auto-detect)
+  autopsy scan           Find autopsies matching files, modules, or tags
+    --dir DIR            Git repo root (default: auto-detect)
+    --files f1,f2        Comma-separated file paths to match
+    --modules m1,m2      Comma-separated module names to match
+    --tags t1,t2         Comma-separated tags to match
+  autopsy infer          Reconstruct autopsy from worktree signals (tome, herald)
+    --dir DIR            Quest worktree directory (required)
+    --repo DIR           Git repo root for storing autopsy (default: auto-detect)
 
 Other:
   version                Print version`)
@@ -742,6 +761,106 @@ func runDashboard(args []string) int {
 		fmt.Fprintf(os.Stderr, "fellowship: %v\n", err)
 		return 1
 	}
+	return 0
+}
+
+func runAutopsy(args []string) int {
+	switch args[0] {
+	case "create":
+		return runAutopsyCreate(args[1:])
+	case "scan":
+		return runAutopsyScan(args[1:])
+	case "infer":
+		return runAutopsyInfer(args[1:])
+	default:
+		fmt.Fprintf(os.Stderr, "unknown autopsy command: %s\n", args[0])
+		return 1
+	}
+}
+
+func runAutopsyCreate(args []string) int {
+	fs := flag.NewFlagSet("autopsy create", flag.ExitOnError)
+	dir := fs.String("dir", "", "Git repo root (default: auto-detect)")
+	fs.Parse(args)
+
+	root := *dir
+	if root == "" {
+		root = gitRootOrCwd()
+	}
+
+	var input autopsy.CreateInput
+	if err := json.NewDecoder(os.Stdin).Decode(&input); err != nil {
+		fmt.Fprintf(os.Stderr, "fellowship: reading JSON from stdin: %v\n", err)
+		return 1
+	}
+
+	path, err := autopsy.Create(root, &input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "fellowship: %v\n", err)
+		return 1
+	}
+	fmt.Printf("Autopsy written to %s\n", path)
+	return 0
+}
+
+func runAutopsyScan(args []string) int {
+	fs := flag.NewFlagSet("autopsy scan", flag.ExitOnError)
+	dir := fs.String("dir", "", "Git repo root (default: auto-detect)")
+	files := fs.String("files", "", "Comma-separated file paths to match")
+	modules := fs.String("modules", "", "Comma-separated module names to match")
+	tags := fs.String("tags", "", "Comma-separated tags to match")
+	fs.Parse(args)
+
+	root := *dir
+	if root == "" {
+		root = gitRootOrCwd()
+	}
+
+	opts := autopsy.ScanOptions{}
+	if *files != "" {
+		opts.Files = strings.Split(*files, ",")
+	}
+	if *modules != "" {
+		opts.Modules = strings.Split(*modules, ",")
+	}
+	if *tags != "" {
+		opts.Tags = strings.Split(*tags, ",")
+	}
+
+	expiryDays := autopsy.ReadExpiryDays()
+	matches, err := autopsy.Scan(root, opts, expiryDays)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "fellowship: %v\n", err)
+		return 1
+	}
+
+	data, _ := json.MarshalIndent(matches, "", "  ")
+	fmt.Println(string(data))
+	return 0
+}
+
+func runAutopsyInfer(args []string) int {
+	fs := flag.NewFlagSet("autopsy infer", flag.ExitOnError)
+	dir := fs.String("dir", "", "Quest worktree directory (required)")
+	repo := fs.String("repo", "", "Git repo root for storing autopsy (default: auto-detect)")
+	fs.Parse(args)
+
+	if *dir == "" {
+		fmt.Fprintln(os.Stderr, "usage: fellowship autopsy infer --dir <worktree> [--repo DIR]")
+		return 1
+	}
+
+	root := *repo
+	if root == "" {
+		root = gitRootOrCwd()
+	}
+
+	path, err := autopsy.Infer(*dir, root)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "fellowship: %v\n", err)
+		return 1
+	}
+	fmt.Printf("Inferred autopsy written to %s\n", path)
 	return 0
 }
 

--- a/cli/internal/autopsy/autopsy.go
+++ b/cli/internal/autopsy/autopsy.go
@@ -1,6 +1,7 @@
 package autopsy
 
 import (
+	"crypto/rand"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -90,7 +91,9 @@ func Create(repoRoot string, input *CreateInput) (string, error) {
 		return "", fmt.Errorf("creating autopsies directory: %w", err)
 	}
 
-	filename := fmt.Sprintf("%s-%s.json", now.Format("20060102T150405"), sanitize(input.Quest))
+	randBytes := make([]byte, 4)
+	rand.Read(randBytes)
+	filename := fmt.Sprintf("%s-%s-%x.json", now.Format("20060102T150405"), sanitize(input.Quest), randBytes)
 	path := filepath.Join(dir, filename)
 
 	data, err := json.MarshalIndent(a, "", "  ")
@@ -173,7 +176,10 @@ func Infer(worktreeDir, repoRoot string) (string, error) {
 	}
 
 	// Determine trigger from signals
-	trigger, whatFailed := inferTrigger(worktreeDir, t)
+	trigger, whatFailed, err := inferTrigger(worktreeDir, t)
+	if err != nil {
+		return "", err
+	}
 	if trigger == "" {
 		return "", fmt.Errorf("no failure signals found in worktree")
 	}
@@ -194,30 +200,33 @@ func Infer(worktreeDir, repoRoot string) (string, error) {
 	return Create(repoRoot, input)
 }
 
-func inferTrigger(worktreeDir string, t *tome.QuestTome) (string, string) {
+func inferTrigger(worktreeDir string, t *tome.QuestTome) (string, string, error) {
 	// Check for respawns
 	if t.Respawns > 0 {
-		return "recovery", fmt.Sprintf("Quest required %d respawn(s)", t.Respawns)
+		return "recovery", fmt.Sprintf("Quest required %d respawn(s)", t.Respawns), nil
 	}
 
 	// Check for gate rejections in herald
-	tidings, _ := herald.Read(worktreeDir, 0)
+	tidings, err := herald.Read(worktreeDir, 0)
+	if err != nil && !os.IsNotExist(err) {
+		return "", "", fmt.Errorf("reading herald: %w", err)
+	}
 	for i := len(tidings) - 1; i >= 0; i-- {
 		if tidings[i].Type == herald.GateRejected {
 			detail := tidings[i].Detail
 			if detail == "" {
 				detail = fmt.Sprintf("Gate rejected at %s phase", tidings[i].Phase)
 			}
-			return "rejection", detail
+			return "rejection", detail, nil
 		}
 	}
 
 	// Check for failed/cancelled status in tome
 	if t.Status == "failed" || t.Status == "cancelled" {
-		return "abandonment", fmt.Sprintf("Quest %s with status: %s", t.QuestName, t.Status)
+		return "abandonment", fmt.Sprintf("Quest %s with status: %s", t.QuestName, t.Status), nil
 	}
 
-	return "", ""
+	return "", "", nil
 }
 
 func inferPhase(t *tome.QuestTome) string {
@@ -247,13 +256,21 @@ func inferModules(files []string) []string {
 }
 
 func matchesFilters(a *Autopsy, opts ScanOptions) bool {
-	// File path prefix match
+	// File match: exact match, directory containment, or same directory
 	for _, queryFile := range opts.Files {
 		for _, autopsyFile := range a.Files {
-			if strings.HasPrefix(autopsyFile, queryFile) || strings.HasPrefix(queryFile, autopsyFile) {
+			// Exact match
+			if queryFile == autopsyFile {
 				return true
 			}
-			// Also match if they share a directory prefix (skip root-level files)
+			// Directory containment (query is a dir prefix of autopsy file or vice versa)
+			if strings.HasSuffix(queryFile, "/") && strings.HasPrefix(autopsyFile, queryFile) {
+				return true
+			}
+			if strings.HasSuffix(autopsyFile, "/") && strings.HasPrefix(queryFile, autopsyFile) {
+				return true
+			}
+			// Same directory (skip root-level files)
 			queryDir := filepath.Dir(queryFile)
 			aDir := filepath.Dir(autopsyFile)
 			if queryDir != "." && aDir != "." && queryDir == aDir {
@@ -296,8 +313,9 @@ func loadAutopsy(path string) (*Autopsy, error) {
 }
 
 func sanitize(s string) string {
-	s = strings.ReplaceAll(s, " ", "-")
-	s = strings.ReplaceAll(s, "/", "-")
+	for _, c := range []string{" ", "/", "\\", ":", "*", "?", "\"", "<", ">", "|"} {
+		s = strings.ReplaceAll(s, c, "-")
+	}
 	if len(s) > 40 {
 		s = s[:40]
 	}

--- a/cli/internal/autopsy/autopsy.go
+++ b/cli/internal/autopsy/autopsy.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -52,6 +53,9 @@ var validTriggers = map[string]bool{
 
 // Create validates input, fills in version/timestamp, and writes to the autopsies directory.
 func Create(repoRoot string, input *CreateInput) (string, error) {
+	if input == nil {
+		return "", fmt.Errorf("input is required")
+	}
 	if input.Quest == "" {
 		return "", fmt.Errorf("quest is required")
 	}
@@ -92,7 +96,9 @@ func Create(repoRoot string, input *CreateInput) (string, error) {
 	}
 
 	randBytes := make([]byte, 4)
-	rand.Read(randBytes)
+	if _, err := rand.Read(randBytes); err != nil {
+		return "", fmt.Errorf("generating autopsy filename suffix: %w", err)
+	}
 	filename := fmt.Sprintf("%s-%s-%x.json", now.Format("20060102T150405"), sanitize(input.Quest), randBytes)
 	path := filepath.Join(dir, filename)
 
@@ -141,18 +147,17 @@ func Scan(repoRoot string, opts ScanOptions, expiryDays int) ([]Autopsy, error) 
 		path := filepath.Join(dir, entry.Name())
 		a, err := loadAutopsy(path)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "fellowship: skipping corrupt autopsy %s: %v\n", entry.Name(), err)
-			continue
+			return nil, fmt.Errorf("reading autopsy %s: %w", entry.Name(), err)
 		}
 
-		// Prune expired or unparseable timestamps
 		ts, err := time.Parse(time.RFC3339, a.Timestamp)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "fellowship: skipping autopsy %s with bad timestamp: %v\n", entry.Name(), err)
-			continue
+			return nil, fmt.Errorf("parsing autopsy timestamp for %s: %w", entry.Name(), err)
 		}
 		if ts.Before(cutoff) {
-			os.Remove(path)
+			if err := os.Remove(path); err != nil {
+				return nil, fmt.Errorf("pruning expired autopsy %s: %w", entry.Name(), err)
+			}
 			continue
 		}
 
@@ -252,6 +257,7 @@ func inferModules(files []string) []string {
 	for m := range seen {
 		modules = append(modules, m)
 	}
+	sort.Strings(modules)
 	return modules
 }
 

--- a/cli/internal/autopsy/autopsy.go
+++ b/cli/internal/autopsy/autopsy.go
@@ -306,25 +306,3 @@ func sanitize(s string) string {
 
 // DefaultExpiryDays is the default autopsy TTL when not configured.
 const DefaultExpiryDays = 90
-
-// ReadExpiryDays reads the autopsy.expiryDays config from ~/.claude/fellowship.json.
-// Returns DefaultExpiryDays if not configured.
-func ReadExpiryDays() int {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return DefaultExpiryDays
-	}
-	data, err := os.ReadFile(filepath.Join(home, ".claude", "fellowship.json"))
-	if err != nil {
-		return DefaultExpiryDays
-	}
-	var cfg struct {
-		Autopsy struct {
-			ExpiryDays int `json:"expiryDays"`
-		} `json:"autopsy"`
-	}
-	if json.Unmarshal(data, &cfg) != nil || cfg.Autopsy.ExpiryDays <= 0 {
-		return DefaultExpiryDays
-	}
-	return cfg.Autopsy.ExpiryDays
-}

--- a/cli/internal/autopsy/autopsy.go
+++ b/cli/internal/autopsy/autopsy.go
@@ -138,11 +138,17 @@ func Scan(repoRoot string, opts ScanOptions, expiryDays int) ([]Autopsy, error) 
 		path := filepath.Join(dir, entry.Name())
 		a, err := loadAutopsy(path)
 		if err != nil {
+			fmt.Fprintf(os.Stderr, "fellowship: skipping corrupt autopsy %s: %v\n", entry.Name(), err)
 			continue
 		}
 
-		// Prune expired
-		if ts, err := time.Parse(time.RFC3339, a.Timestamp); err == nil && ts.Before(cutoff) {
+		// Prune expired or unparseable timestamps
+		ts, err := time.Parse(time.RFC3339, a.Timestamp)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "fellowship: skipping autopsy %s with bad timestamp: %v\n", entry.Name(), err)
+			continue
+		}
+		if ts.Before(cutoff) {
 			os.Remove(path)
 			continue
 		}

--- a/cli/internal/autopsy/autopsy.go
+++ b/cli/internal/autopsy/autopsy.go
@@ -1,0 +1,324 @@
+package autopsy
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/justinjdev/fellowship/cli/internal/datadir"
+	"github.com/justinjdev/fellowship/cli/internal/herald"
+	"github.com/justinjdev/fellowship/cli/internal/tome"
+)
+
+const autopsyDir = "autopsies"
+
+// Autopsy represents a structured failure record.
+type Autopsy struct {
+	Version    int      `json:"version"`
+	Timestamp  string   `json:"ts"`
+	Quest      string   `json:"quest"`
+	Task       string   `json:"task"`
+	Phase      string   `json:"phase"`
+	Trigger    string   `json:"trigger"` // "recovery", "rejection", "abandonment"
+	Files      []string `json:"files"`
+	Modules    []string `json:"modules"`
+	WhatFailed string   `json:"what_failed"`
+	Resolution string   `json:"resolution,omitempty"`
+	Tags       []string `json:"tags"`
+}
+
+// CreateInput is the subset of fields the caller provides; version and timestamp are filled in.
+type CreateInput struct {
+	Quest      string   `json:"quest"`
+	Task       string   `json:"task"`
+	Phase      string   `json:"phase"`
+	Trigger    string   `json:"trigger"`
+	Files      []string `json:"files"`
+	Modules    []string `json:"modules"`
+	WhatFailed string   `json:"what_failed"`
+	Resolution string   `json:"resolution,omitempty"`
+	Tags       []string `json:"tags,omitempty"`
+}
+
+var validTriggers = map[string]bool{
+	"recovery":    true,
+	"rejection":   true,
+	"abandonment": true,
+}
+
+// Create validates input, fills in version/timestamp, and writes to the autopsies directory.
+func Create(repoRoot string, input *CreateInput) (string, error) {
+	if input.Quest == "" {
+		return "", fmt.Errorf("quest is required")
+	}
+	if input.WhatFailed == "" {
+		return "", fmt.Errorf("what_failed is required")
+	}
+	if !validTriggers[input.Trigger] {
+		return "", fmt.Errorf("invalid trigger %q (must be recovery, rejection, or abandonment)", input.Trigger)
+	}
+
+	now := time.Now().UTC()
+	a := &Autopsy{
+		Version:    1,
+		Timestamp:  now.Format(time.RFC3339),
+		Quest:      input.Quest,
+		Task:       input.Task,
+		Phase:      input.Phase,
+		Trigger:    input.Trigger,
+		Files:      input.Files,
+		Modules:    input.Modules,
+		WhatFailed: input.WhatFailed,
+		Resolution: input.Resolution,
+		Tags:       input.Tags,
+	}
+	if a.Files == nil {
+		a.Files = []string{}
+	}
+	if a.Modules == nil {
+		a.Modules = []string{}
+	}
+	if a.Tags == nil {
+		a.Tags = []string{}
+	}
+
+	dir := filepath.Join(repoRoot, datadir.Name(), autopsyDir)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return "", fmt.Errorf("creating autopsies directory: %w", err)
+	}
+
+	filename := fmt.Sprintf("%s-%s.json", now.Format("20060102T150405"), sanitize(input.Quest))
+	path := filepath.Join(dir, filename)
+
+	data, err := json.MarshalIndent(a, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshaling autopsy: %w", err)
+	}
+	data = append(data, '\n')
+
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return "", fmt.Errorf("writing autopsy: %w", err)
+	}
+	return path, nil
+}
+
+// ScanOptions configures which autopsies to match.
+type ScanOptions struct {
+	Files   []string
+	Modules []string
+	Tags    []string
+}
+
+// Scan reads all autopsies from the repo root, prunes expired ones, and returns matches.
+func Scan(repoRoot string, opts ScanOptions, expiryDays int) ([]Autopsy, error) {
+	if len(opts.Files) == 0 && len(opts.Modules) == 0 && len(opts.Tags) == 0 {
+		return nil, fmt.Errorf("at least one of --files, --modules, or --tags is required")
+	}
+
+	dir := filepath.Join(repoRoot, datadir.Name(), autopsyDir)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []Autopsy{}, nil
+		}
+		return nil, fmt.Errorf("reading autopsies directory: %w", err)
+	}
+
+	cutoff := time.Now().UTC().AddDate(0, 0, -expiryDays)
+	var matches []Autopsy
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+
+		path := filepath.Join(dir, entry.Name())
+		a, err := loadAutopsy(path)
+		if err != nil {
+			continue
+		}
+
+		// Prune expired
+		if ts, err := time.Parse(time.RFC3339, a.Timestamp); err == nil && ts.Before(cutoff) {
+			os.Remove(path)
+			continue
+		}
+
+		if matchesFilters(a, opts) {
+			matches = append(matches, *a)
+		}
+	}
+
+	if matches == nil {
+		matches = []Autopsy{}
+	}
+	return matches, nil
+}
+
+// Infer reconstructs a best-effort autopsy from a quest worktree's external signals.
+func Infer(worktreeDir, repoRoot string) (string, error) {
+	tomePath := filepath.Join(worktreeDir, datadir.Name(), "quest-tome.json")
+	t, err := tome.Load(tomePath)
+	if err != nil {
+		return "", fmt.Errorf("loading tome: %w", err)
+	}
+
+	// Determine trigger from signals
+	trigger, whatFailed := inferTrigger(worktreeDir, t)
+	if trigger == "" {
+		return "", fmt.Errorf("no failure signals found in worktree")
+	}
+
+	// Derive modules from files_touched
+	modules := inferModules(t.FilesTouched)
+
+	input := &CreateInput{
+		Quest:      t.QuestName,
+		Task:       t.Task,
+		Phase:      inferPhase(t),
+		Trigger:    trigger,
+		Files:      t.FilesTouched,
+		Modules:    modules,
+		WhatFailed: whatFailed,
+	}
+
+	return Create(repoRoot, input)
+}
+
+func inferTrigger(worktreeDir string, t *tome.QuestTome) (string, string) {
+	// Check for respawns
+	if t.Respawns > 0 {
+		return "recovery", fmt.Sprintf("Quest required %d respawn(s)", t.Respawns)
+	}
+
+	// Check for gate rejections in herald
+	tidings, _ := herald.Read(worktreeDir, 0)
+	for i := len(tidings) - 1; i >= 0; i-- {
+		if tidings[i].Type == herald.GateRejected {
+			detail := tidings[i].Detail
+			if detail == "" {
+				detail = fmt.Sprintf("Gate rejected at %s phase", tidings[i].Phase)
+			}
+			return "rejection", detail
+		}
+	}
+
+	// Check for failed/cancelled status in tome
+	if t.Status == "failed" || t.Status == "cancelled" {
+		return "abandonment", fmt.Sprintf("Quest %s with status: %s", t.QuestName, t.Status)
+	}
+
+	return "", ""
+}
+
+func inferPhase(t *tome.QuestTome) string {
+	if len(t.PhasesCompleted) > 0 {
+		return t.PhasesCompleted[len(t.PhasesCompleted)-1].Phase
+	}
+	return "unknown"
+}
+
+func inferModules(files []string) []string {
+	seen := map[string]bool{}
+	for _, f := range files {
+		parts := strings.Split(filepath.ToSlash(f), "/")
+		if len(parts) >= 2 {
+			// Use the first directory component as the module
+			mod := parts[0]
+			if !seen[mod] {
+				seen[mod] = true
+			}
+		}
+	}
+	modules := make([]string, 0, len(seen))
+	for m := range seen {
+		modules = append(modules, m)
+	}
+	return modules
+}
+
+func matchesFilters(a *Autopsy, opts ScanOptions) bool {
+	// File path prefix match
+	for _, queryFile := range opts.Files {
+		for _, autopsyFile := range a.Files {
+			if strings.HasPrefix(autopsyFile, queryFile) || strings.HasPrefix(queryFile, autopsyFile) {
+				return true
+			}
+			// Also match if they share a directory prefix
+			queryDir := filepath.Dir(queryFile)
+			autopsyDir := filepath.Dir(autopsyFile)
+			if queryDir == autopsyDir {
+				return true
+			}
+		}
+	}
+
+	// Module match
+	for _, queryMod := range opts.Modules {
+		for _, autopsyMod := range a.Modules {
+			if queryMod == autopsyMod {
+				return true
+			}
+		}
+	}
+
+	// Tag match
+	for _, queryTag := range opts.Tags {
+		for _, autopsyTag := range a.Tags {
+			if queryTag == autopsyTag {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func loadAutopsy(path string) (*Autopsy, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var a Autopsy
+	if err := json.Unmarshal(data, &a); err != nil {
+		return nil, err
+	}
+	return &a, nil
+}
+
+func sanitize(s string) string {
+	s = strings.ReplaceAll(s, " ", "-")
+	s = strings.ReplaceAll(s, "/", "-")
+	if len(s) > 40 {
+		s = s[:40]
+	}
+	return s
+}
+
+// DefaultExpiryDays is the default autopsy TTL when not configured.
+const DefaultExpiryDays = 90
+
+// ReadExpiryDays reads the autopsy.expiryDays config from ~/.claude/fellowship.json.
+// Returns DefaultExpiryDays if not configured.
+func ReadExpiryDays() int {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return DefaultExpiryDays
+	}
+	data, err := os.ReadFile(filepath.Join(home, ".claude", "fellowship.json"))
+	if err != nil {
+		return DefaultExpiryDays
+	}
+	var cfg struct {
+		Autopsy struct {
+			ExpiryDays int `json:"expiryDays"`
+		} `json:"autopsy"`
+	}
+	if json.Unmarshal(data, &cfg) != nil || cfg.Autopsy.ExpiryDays <= 0 {
+		return DefaultExpiryDays
+	}
+	return cfg.Autopsy.ExpiryDays
+}

--- a/cli/internal/autopsy/autopsy.go
+++ b/cli/internal/autopsy/autopsy.go
@@ -253,10 +253,10 @@ func matchesFilters(a *Autopsy, opts ScanOptions) bool {
 			if strings.HasPrefix(autopsyFile, queryFile) || strings.HasPrefix(queryFile, autopsyFile) {
 				return true
 			}
-			// Also match if they share a directory prefix
+			// Also match if they share a directory prefix (skip root-level files)
 			queryDir := filepath.Dir(queryFile)
-			autopsyDir := filepath.Dir(autopsyFile)
-			if queryDir == autopsyDir {
+			aDir := filepath.Dir(autopsyFile)
+			if queryDir != "." && aDir != "." && queryDir == aDir {
 				return true
 			}
 		}

--- a/cli/internal/autopsy/autopsy_test.go
+++ b/cli/internal/autopsy/autopsy_test.go
@@ -1,0 +1,459 @@
+package autopsy
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/justinjdev/fellowship/cli/internal/datadir"
+	"github.com/justinjdev/fellowship/cli/internal/herald"
+	"github.com/justinjdev/fellowship/cli/internal/tome"
+)
+
+func setupTestRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, datadir.DefaultName, autopsyDir), 0755)
+	return dir
+}
+
+func TestCreate_ValidInput(t *testing.T) {
+	repo := setupTestRepo(t)
+	input := &CreateInput{
+		Quest:      "quest-1",
+		Task:       "Add auth endpoint",
+		Phase:      "Implement",
+		Trigger:    "recovery",
+		Files:      []string{"src/auth/jwt.go"},
+		Modules:    []string{"auth"},
+		WhatFailed: "Middleware caches tokens",
+		Resolution: "Added cache invalidation",
+		Tags:       []string{"caching"},
+	}
+
+	path, err := Create(repo, input)
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading autopsy file: %v", err)
+	}
+
+	var a Autopsy
+	if err := json.Unmarshal(data, &a); err != nil {
+		t.Fatalf("parsing autopsy: %v", err)
+	}
+
+	if a.Version != 1 {
+		t.Errorf("version = %d, want 1", a.Version)
+	}
+	if a.Quest != "quest-1" {
+		t.Errorf("quest = %q, want %q", a.Quest, "quest-1")
+	}
+	if a.Trigger != "recovery" {
+		t.Errorf("trigger = %q, want %q", a.Trigger, "recovery")
+	}
+	if a.WhatFailed != "Middleware caches tokens" {
+		t.Errorf("what_failed = %q", a.WhatFailed)
+	}
+	if len(a.Tags) != 1 || a.Tags[0] != "caching" {
+		t.Errorf("tags = %v, want [caching]", a.Tags)
+	}
+}
+
+func TestCreate_MissingQuest(t *testing.T) {
+	repo := setupTestRepo(t)
+	_, err := Create(repo, &CreateInput{
+		Trigger:    "recovery",
+		WhatFailed: "something",
+	})
+	if err == nil {
+		t.Error("expected error for missing quest")
+	}
+}
+
+func TestCreate_InvalidTrigger(t *testing.T) {
+	repo := setupTestRepo(t)
+	_, err := Create(repo, &CreateInput{
+		Quest:      "quest-1",
+		Trigger:    "invalid",
+		WhatFailed: "something",
+	})
+	if err == nil {
+		t.Error("expected error for invalid trigger")
+	}
+}
+
+func TestCreate_MissingWhatFailed(t *testing.T) {
+	repo := setupTestRepo(t)
+	_, err := Create(repo, &CreateInput{
+		Quest:   "quest-1",
+		Trigger: "recovery",
+	})
+	if err == nil {
+		t.Error("expected error for missing what_failed")
+	}
+}
+
+func TestCreate_NilSlicesDefaultToEmpty(t *testing.T) {
+	repo := setupTestRepo(t)
+	path, err := Create(repo, &CreateInput{
+		Quest:      "quest-1",
+		Trigger:    "recovery",
+		WhatFailed: "something",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	data, _ := os.ReadFile(path)
+	var a Autopsy
+	json.Unmarshal(data, &a)
+
+	if a.Files == nil {
+		t.Error("files should be empty slice, not nil")
+	}
+	if a.Modules == nil {
+		t.Error("modules should be empty slice, not nil")
+	}
+	if a.Tags == nil {
+		t.Error("tags should be empty slice, not nil")
+	}
+}
+
+func TestScan_MatchByFile(t *testing.T) {
+	repo := setupTestRepo(t)
+	Create(repo, &CreateInput{
+		Quest:      "quest-1",
+		Trigger:    "recovery",
+		Files:      []string{"src/auth/jwt.go"},
+		WhatFailed: "auth issue",
+	})
+
+	matches, err := Scan(repo, ScanOptions{Files: []string{"src/auth/middleware.go"}}, 90)
+	if err != nil {
+		t.Fatalf("Scan failed: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Errorf("expected 1 match (same directory), got %d", len(matches))
+	}
+}
+
+func TestScan_MatchByModule(t *testing.T) {
+	repo := setupTestRepo(t)
+	Create(repo, &CreateInput{
+		Quest:      "quest-1",
+		Trigger:    "recovery",
+		Modules:    []string{"auth"},
+		WhatFailed: "auth issue",
+	})
+
+	matches, err := Scan(repo, ScanOptions{Modules: []string{"auth"}}, 90)
+	if err != nil {
+		t.Fatalf("Scan failed: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Errorf("expected 1 match, got %d", len(matches))
+	}
+}
+
+func TestScan_MatchByTag(t *testing.T) {
+	repo := setupTestRepo(t)
+	Create(repo, &CreateInput{
+		Quest:      "quest-1",
+		Trigger:    "recovery",
+		Tags:       []string{"caching", "auth"},
+		WhatFailed: "cache issue",
+	})
+
+	matches, err := Scan(repo, ScanOptions{Tags: []string{"caching"}}, 90)
+	if err != nil {
+		t.Fatalf("Scan failed: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Errorf("expected 1 match, got %d", len(matches))
+	}
+}
+
+func TestScan_NoMatch(t *testing.T) {
+	repo := setupTestRepo(t)
+	Create(repo, &CreateInput{
+		Quest:      "quest-1",
+		Trigger:    "recovery",
+		Modules:    []string{"auth"},
+		WhatFailed: "auth issue",
+	})
+
+	matches, err := Scan(repo, ScanOptions{Modules: []string{"billing"}}, 90)
+	if err != nil {
+		t.Fatalf("Scan failed: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Errorf("expected 0 matches, got %d", len(matches))
+	}
+}
+
+func TestScan_PrunesExpired(t *testing.T) {
+	repo := setupTestRepo(t)
+
+	// Write an autopsy with an old timestamp
+	dir := filepath.Join(repo, datadir.DefaultName, autopsyDir)
+	old := &Autopsy{
+		Version:    1,
+		Timestamp:  time.Now().UTC().AddDate(0, 0, -100).Format(time.RFC3339),
+		Quest:      "old-quest",
+		Trigger:    "recovery",
+		Modules:    []string{"auth"},
+		Files:      []string{},
+		Tags:       []string{},
+		WhatFailed: "old failure",
+	}
+	data, _ := json.MarshalIndent(old, "", "  ")
+	os.WriteFile(filepath.Join(dir, "old-autopsy.json"), data, 0644)
+
+	matches, err := Scan(repo, ScanOptions{Modules: []string{"auth"}}, 90)
+	if err != nil {
+		t.Fatalf("Scan failed: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Errorf("expired autopsy should be pruned, got %d matches", len(matches))
+	}
+
+	// Verify file was deleted
+	if _, err := os.Stat(filepath.Join(dir, "old-autopsy.json")); !os.IsNotExist(err) {
+		t.Error("expired autopsy file should be deleted")
+	}
+}
+
+func TestScan_RequiresFilter(t *testing.T) {
+	repo := setupTestRepo(t)
+	_, err := Scan(repo, ScanOptions{}, 90)
+	if err == nil {
+		t.Error("expected error when no filters provided")
+	}
+}
+
+func TestScan_EmptyDirectory(t *testing.T) {
+	repo := t.TempDir() // no autopsies dir
+	matches, err := Scan(repo, ScanOptions{Modules: []string{"auth"}}, 90)
+	if err != nil {
+		t.Fatalf("Scan failed: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Errorf("expected 0 matches for empty dir, got %d", len(matches))
+	}
+}
+
+func TestInfer_FromRespawns(t *testing.T) {
+	worktree := t.TempDir()
+	repo := t.TempDir()
+	os.MkdirAll(filepath.Join(repo, datadir.DefaultName, autopsyDir), 0755)
+
+	// Write a tome with respawns
+	tomeDir := filepath.Join(worktree, datadir.DefaultName)
+	os.MkdirAll(tomeDir, 0755)
+	qt := &tome.QuestTome{
+		Version:   1,
+		QuestName: "quest-respawned",
+		Task:      "Fix login flow",
+		Status:    "active",
+		PhasesCompleted: []tome.PhaseRecord{
+			{Phase: "Implement", CompletedAt: time.Now().UTC().Format(time.RFC3339)},
+		},
+		GateHistory:  []tome.GateEvent{},
+		FilesTouched: []string{"src/auth/login.go", "src/auth/session.go"},
+		Respawns:     2,
+	}
+	tome.Save(filepath.Join(tomeDir, "quest-tome.json"), qt)
+
+	path, err := Infer(worktree, repo)
+	if err != nil {
+		t.Fatalf("Infer failed: %v", err)
+	}
+
+	data, _ := os.ReadFile(path)
+	var a Autopsy
+	json.Unmarshal(data, &a)
+
+	if a.Trigger != "recovery" {
+		t.Errorf("trigger = %q, want recovery", a.Trigger)
+	}
+	if a.Quest != "quest-respawned" {
+		t.Errorf("quest = %q", a.Quest)
+	}
+	if len(a.Files) != 2 {
+		t.Errorf("files = %v, want 2 files", a.Files)
+	}
+}
+
+func TestInfer_FromRejection(t *testing.T) {
+	worktree := t.TempDir()
+	repo := t.TempDir()
+	os.MkdirAll(filepath.Join(repo, datadir.DefaultName, autopsyDir), 0755)
+
+	// Write tome
+	tomeDir := filepath.Join(worktree, datadir.DefaultName)
+	os.MkdirAll(tomeDir, 0755)
+	qt := &tome.QuestTome{
+		Version:         1,
+		QuestName:       "quest-rejected",
+		Task:            "Add billing",
+		Status:          "active",
+		PhasesCompleted: []tome.PhaseRecord{{Phase: "Plan", CompletedAt: time.Now().UTC().Format(time.RFC3339)}},
+		GateHistory:     []tome.GateEvent{},
+		FilesTouched:    []string{"src/billing/charge.go"},
+	}
+	tome.Save(filepath.Join(tomeDir, "quest-tome.json"), qt)
+
+	// Write herald with rejection
+	herald.Announce(worktree, herald.Tiding{
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Quest:     "quest-rejected",
+		Type:      herald.GateRejected,
+		Phase:     "Plan",
+		Detail:    "Plan doesn't account for tax calculation",
+	})
+
+	path, err := Infer(worktree, repo)
+	if err != nil {
+		t.Fatalf("Infer failed: %v", err)
+	}
+
+	data, _ := os.ReadFile(path)
+	var a Autopsy
+	json.Unmarshal(data, &a)
+
+	if a.Trigger != "rejection" {
+		t.Errorf("trigger = %q, want rejection", a.Trigger)
+	}
+	if a.WhatFailed != "Plan doesn't account for tax calculation" {
+		t.Errorf("what_failed = %q", a.WhatFailed)
+	}
+}
+
+func TestInfer_FromAbandonment(t *testing.T) {
+	worktree := t.TempDir()
+	repo := t.TempDir()
+	os.MkdirAll(filepath.Join(repo, datadir.DefaultName, autopsyDir), 0755)
+
+	tomeDir := filepath.Join(worktree, datadir.DefaultName)
+	os.MkdirAll(tomeDir, 0755)
+	qt := &tome.QuestTome{
+		Version:         1,
+		QuestName:       "quest-abandoned",
+		Task:            "Migrate DB",
+		Status:          "cancelled",
+		PhasesCompleted: []tome.PhaseRecord{},
+		GateHistory:     []tome.GateEvent{},
+		FilesTouched:    []string{},
+	}
+	tome.Save(filepath.Join(tomeDir, "quest-tome.json"), qt)
+
+	path, err := Infer(worktree, repo)
+	if err != nil {
+		t.Fatalf("Infer failed: %v", err)
+	}
+
+	data, _ := os.ReadFile(path)
+	var a Autopsy
+	json.Unmarshal(data, &a)
+
+	if a.Trigger != "abandonment" {
+		t.Errorf("trigger = %q, want abandonment", a.Trigger)
+	}
+}
+
+func TestInfer_NoFailureSignals(t *testing.T) {
+	worktree := t.TempDir()
+	repo := t.TempDir()
+
+	tomeDir := filepath.Join(worktree, datadir.DefaultName)
+	os.MkdirAll(tomeDir, 0755)
+	qt := &tome.QuestTome{
+		Version:         1,
+		QuestName:       "quest-ok",
+		Task:            "Add feature",
+		Status:          "active",
+		PhasesCompleted: []tome.PhaseRecord{},
+		GateHistory:     []tome.GateEvent{},
+		FilesTouched:    []string{},
+	}
+	tome.Save(filepath.Join(tomeDir, "quest-tome.json"), qt)
+
+	_, err := Infer(worktree, repo)
+	if err == nil {
+		t.Error("expected error when no failure signals found")
+	}
+}
+
+func TestMatchesFilters_FilePrefix(t *testing.T) {
+	a := &Autopsy{Files: []string{"src/auth/jwt.go"}}
+
+	// Same directory should match
+	if !matchesFilters(a, ScanOptions{Files: []string{"src/auth/middleware.go"}}) {
+		t.Error("same directory should match")
+	}
+
+	// Parent prefix should match
+	if !matchesFilters(a, ScanOptions{Files: []string{"src/auth/"}}) {
+		t.Error("parent prefix should match")
+	}
+
+	// Different directory should not match
+	if matchesFilters(a, ScanOptions{Files: []string{"src/billing/charge.go"}}) {
+		t.Error("different directory should not match")
+	}
+}
+
+func TestInferModules(t *testing.T) {
+	modules := inferModules([]string{"src/auth/jwt.go", "src/auth/session.go", "src/billing/charge.go"})
+	if len(modules) != 1 {
+		// Both start with "src"
+		t.Logf("modules = %v", modules)
+	}
+
+	modules = inferModules([]string{"auth/jwt.go", "billing/charge.go"})
+	seen := map[string]bool{}
+	for _, m := range modules {
+		seen[m] = true
+	}
+	if !seen["auth"] || !seen["billing"] {
+		t.Errorf("expected auth and billing modules, got %v", modules)
+	}
+}
+
+func TestSanitize(t *testing.T) {
+	if got := sanitize("quest with spaces"); got != "quest-with-spaces" {
+		t.Errorf("sanitize spaces: got %q", got)
+	}
+	if got := sanitize("quest/with/slashes"); got != "quest-with-slashes" {
+		t.Errorf("sanitize slashes: got %q", got)
+	}
+	long := "this-is-a-very-long-quest-name-that-exceeds-the-forty-character-limit"
+	if got := sanitize(long); len(got) != 40 {
+		t.Errorf("sanitize long: got length %d, want 40", len(got))
+	}
+}
+
+func TestReadExpiryDays_Default(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	if got := ReadExpiryDays(); got != DefaultExpiryDays {
+		t.Errorf("ReadExpiryDays = %d, want %d", got, DefaultExpiryDays)
+	}
+}
+
+func TestReadExpiryDays_Custom(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	os.MkdirAll(filepath.Join(home, ".claude"), 0755)
+	data := []byte(`{"autopsy":{"expiryDays":30}}`)
+	os.WriteFile(filepath.Join(home, ".claude", "fellowship.json"), data, 0644)
+
+	if got := ReadExpiryDays(); got != 30 {
+		t.Errorf("ReadExpiryDays = %d, want 30", got)
+	}
+}

--- a/cli/internal/autopsy/autopsy_test.go
+++ b/cli/internal/autopsy/autopsy_test.go
@@ -111,9 +111,14 @@ func TestCreate_NilSlicesDefaultToEmpty(t *testing.T) {
 		t.Fatalf("Create failed: %v", err)
 	}
 
-	data, _ := os.ReadFile(path)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading autopsy file: %v", err)
+	}
 	var a Autopsy
-	json.Unmarshal(data, &a)
+	if err := json.Unmarshal(data, &a); err != nil {
+		t.Fatalf("parsing autopsy: %v", err)
+	}
 
 	if a.Files == nil {
 		t.Error("files should be empty slice, not nil")

--- a/cli/internal/autopsy/autopsy_test.go
+++ b/cli/internal/autopsy/autopsy_test.go
@@ -439,21 +439,3 @@ func TestSanitize(t *testing.T) {
 	}
 }
 
-func TestReadExpiryDays_Default(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	if got := ReadExpiryDays(); got != DefaultExpiryDays {
-		t.Errorf("ReadExpiryDays = %d, want %d", got, DefaultExpiryDays)
-	}
-}
-
-func TestReadExpiryDays_Custom(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	os.MkdirAll(filepath.Join(home, ".claude"), 0755)
-	data := []byte(`{"autopsy":{"expiryDays":30}}`)
-	os.WriteFile(filepath.Join(home, ".claude", "fellowship.json"), data, 0644)
-
-	if got := ReadExpiryDays(); got != 30 {
-		t.Errorf("ReadExpiryDays = %d, want 30", got)
-	}
-}

--- a/cli/internal/autopsy/autopsy_test.go
+++ b/cli/internal/autopsy/autopsy_test.go
@@ -14,6 +14,7 @@ import (
 
 func setupTestRepo(t *testing.T) string {
 	t.Helper()
+	t.Setenv("HOME", t.TempDir()) // Pin HOME so datadir.Name() returns default
 	dir := t.TempDir()
 	os.MkdirAll(filepath.Join(dir, datadir.DefaultName, autopsyDir), 0755)
 	return dir
@@ -249,6 +250,7 @@ func TestScan_EmptyDirectory(t *testing.T) {
 }
 
 func TestInfer_FromRespawns(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
 	worktree := t.TempDir()
 	repo := t.TempDir()
 	os.MkdirAll(filepath.Join(repo, datadir.DefaultName, autopsyDir), 0755)
@@ -291,6 +293,7 @@ func TestInfer_FromRespawns(t *testing.T) {
 }
 
 func TestInfer_FromRejection(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
 	worktree := t.TempDir()
 	repo := t.TempDir()
 	os.MkdirAll(filepath.Join(repo, datadir.DefaultName, autopsyDir), 0755)
@@ -336,6 +339,7 @@ func TestInfer_FromRejection(t *testing.T) {
 }
 
 func TestInfer_FromAbandonment(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
 	worktree := t.TempDir()
 	repo := t.TempDir()
 	os.MkdirAll(filepath.Join(repo, datadir.DefaultName, autopsyDir), 0755)
@@ -368,6 +372,7 @@ func TestInfer_FromAbandonment(t *testing.T) {
 }
 
 func TestInfer_NoFailureSignals(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
 	worktree := t.TempDir()
 	repo := t.TempDir()
 

--- a/cli/internal/autopsy/autopsy_test.go
+++ b/cli/internal/autopsy/autopsy_test.go
@@ -100,6 +100,14 @@ func TestCreate_MissingWhatFailed(t *testing.T) {
 	}
 }
 
+func TestCreate_NilInput(t *testing.T) {
+	repo := setupTestRepo(t)
+	_, err := Create(repo, nil)
+	if err == nil {
+		t.Error("expected error for nil input")
+	}
+}
+
 func TestCreate_NilSlicesDefaultToEmpty(t *testing.T) {
 	repo := setupTestRepo(t)
 	path, err := Create(repo, &CreateInput{
@@ -282,9 +290,14 @@ func TestInfer_FromRespawns(t *testing.T) {
 		t.Fatalf("Infer failed: %v", err)
 	}
 
-	data, _ := os.ReadFile(path)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading autopsy file: %v", err)
+	}
 	var a Autopsy
-	json.Unmarshal(data, &a)
+	if err := json.Unmarshal(data, &a); err != nil {
+		t.Fatalf("parsing autopsy: %v", err)
+	}
 
 	if a.Trigger != "recovery" {
 		t.Errorf("trigger = %q, want recovery", a.Trigger)
@@ -331,9 +344,14 @@ func TestInfer_FromRejection(t *testing.T) {
 		t.Fatalf("Infer failed: %v", err)
 	}
 
-	data, _ := os.ReadFile(path)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading autopsy file: %v", err)
+	}
 	var a Autopsy
-	json.Unmarshal(data, &a)
+	if err := json.Unmarshal(data, &a); err != nil {
+		t.Fatalf("parsing autopsy: %v", err)
+	}
 
 	if a.Trigger != "rejection" {
 		t.Errorf("trigger = %q, want rejection", a.Trigger)
@@ -367,9 +385,14 @@ func TestInfer_FromAbandonment(t *testing.T) {
 		t.Fatalf("Infer failed: %v", err)
 	}
 
-	data, _ := os.ReadFile(path)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading autopsy file: %v", err)
+	}
 	var a Autopsy
-	json.Unmarshal(data, &a)
+	if err := json.Unmarshal(data, &a); err != nil {
+		t.Fatalf("parsing autopsy: %v", err)
+	}
 
 	if a.Trigger != "abandonment" {
 		t.Errorf("trigger = %q, want abandonment", a.Trigger)
@@ -420,19 +443,16 @@ func TestMatchesFilters_FilePrefix(t *testing.T) {
 }
 
 func TestInferModules(t *testing.T) {
+	// All files start with "src", so we expect a single "src" module
 	modules := inferModules([]string{"src/auth/jwt.go", "src/auth/session.go", "src/billing/charge.go"})
-	if len(modules) != 1 {
-		// Both start with "src"
-		t.Logf("modules = %v", modules)
+	if len(modules) != 1 || modules[0] != "src" {
+		t.Errorf("expected [src], got %v", modules)
 	}
 
+	// Different top-level dirs produce separate modules, sorted
 	modules = inferModules([]string{"auth/jwt.go", "billing/charge.go"})
-	seen := map[string]bool{}
-	for _, m := range modules {
-		seen[m] = true
-	}
-	if !seen["auth"] || !seen["billing"] {
-		t.Errorf("expected auth and billing modules, got %v", modules)
+	if len(modules) != 2 || modules[0] != "auth" || modules[1] != "billing" {
+		t.Errorf("expected [auth billing], got %v", modules)
 	}
 }
 

--- a/cli/internal/datadir/datadir.go
+++ b/cli/internal/datadir/datadir.go
@@ -98,3 +98,25 @@ var gitRootFunc = func() (string, error) {
 func gitRoot() (string, error) {
 	return gitRootFunc()
 }
+
+// AutopsyExpiryDays reads autopsy.expiryDays from ~/.claude/fellowship.json.
+// Returns the provided defaultDays if not configured or on any error.
+func AutopsyExpiryDays(defaultDays int) int {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return defaultDays
+	}
+	data, err := os.ReadFile(filepath.Join(home, ".claude", "fellowship.json"))
+	if err != nil {
+		return defaultDays
+	}
+	var c struct {
+		Autopsy struct {
+			ExpiryDays int `json:"expiryDays"`
+		} `json:"autopsy"`
+	}
+	if json.Unmarshal(data, &c) != nil || c.Autopsy.ExpiryDays <= 0 {
+		return defaultDays
+	}
+	return c.Autopsy.ExpiryDays
+}

--- a/cli/internal/datadir/datadir.go
+++ b/cli/internal/datadir/datadir.go
@@ -15,6 +15,9 @@ const DefaultName = ".fellowship"
 // cfg holds the subset of fellowship config the CLI cares about.
 type cfg struct {
 	DataDir string `json:"dataDir"`
+	Autopsy struct {
+		ExpiryDays int `json:"expiryDays"`
+	} `json:"autopsy"`
 }
 
 var (
@@ -102,20 +105,8 @@ func gitRoot() (string, error) {
 // AutopsyExpiryDays reads autopsy.expiryDays from ~/.claude/fellowship.json.
 // Returns the provided defaultDays if not configured or on any error.
 func AutopsyExpiryDays(defaultDays int) int {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return defaultDays
-	}
-	data, err := os.ReadFile(filepath.Join(home, ".claude", "fellowship.json"))
-	if err != nil {
-		return defaultDays
-	}
-	var c struct {
-		Autopsy struct {
-			ExpiryDays int `json:"expiryDays"`
-		} `json:"autopsy"`
-	}
-	if json.Unmarshal(data, &c) != nil || c.Autopsy.ExpiryDays <= 0 {
+	c := readUserConfig()
+	if c.Autopsy.ExpiryDays <= 0 {
 		return defaultDays
 	}
 	return c.Autopsy.ExpiryDays

--- a/cli/internal/datadir/datadir_test.go
+++ b/cli/internal/datadir/datadir_test.go
@@ -261,6 +261,24 @@ func TestIsDataDirPath(t *testing.T) {
 	}
 }
 
+func TestAutopsyExpiryDays_Default(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	if got := AutopsyExpiryDays(90); got != 90 {
+		t.Errorf("AutopsyExpiryDays = %d, want 90", got)
+	}
+}
+
+func TestAutopsyExpiryDays_Custom(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	os.MkdirAll(filepath.Join(home, ".claude"), 0755)
+	os.WriteFile(filepath.Join(home, ".claude", "fellowship.json"), []byte(`{"autopsy":{"expiryDays":30}}`), 0644)
+
+	if got := AutopsyExpiryDays(90); got != 30 {
+		t.Errorf("AutopsyExpiryDays = %d, want 30", got)
+	}
+}
+
 func TestIsDataDirPath_CustomDir(t *testing.T) {
 	resetCache(t)
 	home := t.TempDir()

--- a/cli/internal/hooks/guard.go
+++ b/cli/internal/hooks/guard.go
@@ -49,9 +49,9 @@ func GateGuard(s *state.State, input *HookInput) HookResult {
 	return HookResult{}
 }
 
-// isFellowshipEscapeCommand returns true for any fellowship CLI command.
-// Fellowship commands operate on state files, not source code, so they should
-// always be allowed through even when gate_pending is true.
+// isFellowshipEscapeCommand returns true for fellowship CLI commands that are
+// safe to execute even when gate_pending is true. These are commands that
+// operate on state/metadata files, not source code.
 //
 // Shell metacharacters are rejected to prevent bypass abuse (e.g., chaining
 // a destructive command after fellowship via "&&" or ";").
@@ -68,6 +68,21 @@ func isFellowshipEscapeCommand(command string) bool {
 	}
 	// Accept bare "fellowship" or any path ending in "/fellowship".
 	bin := fields[0]
-	return bin == "fellowship" || strings.HasSuffix(bin, "/fellowship")
+	if bin != "fellowship" && !strings.HasSuffix(bin, "/fellowship") {
+		return false
+	}
+	// Allowlist of subcommands safe to run during gate_pending.
+	allowed := map[string]bool{
+		"gate":    true, // approve/reject gates
+		"init":    true, // reset state file
+		"autopsy": true, // write/read failure records
+		"errand":  true, // read/update errand status
+		"status":  true, // read-only status scan
+		"eagles":  true, // read-only health scan
+		"tome":    true, // read-only quest history
+		"herald":  true, // read-only event log
+		"version": true, // print version
+	}
+	return allowed[fields[1]]
 }
 

--- a/cli/internal/hooks/guard.go
+++ b/cli/internal/hooks/guard.go
@@ -49,13 +49,12 @@ func GateGuard(s *state.State, input *HookInput) HookResult {
 	return HookResult{}
 }
 
-// isFellowshipEscapeCommand returns true for fellowship CLI commands that must
-// be allowed through even when gate_pending is true — specifically the commands
-// needed to unstick a blocked session without requiring user intervention.
+// isFellowshipEscapeCommand returns true for any fellowship CLI command.
+// Fellowship commands operate on state files, not source code, so they should
+// always be allowed through even when gate_pending is true.
 //
-// The command is tokenized and matched exactly against the fellowship binary
-// plus the allowed subcommands (gate reject, gate approve, init). Shell
-// metacharacters are rejected to prevent bypass abuse.
+// Shell metacharacters are rejected to prevent bypass abuse (e.g., chaining
+// a destructive command after fellowship via "&&" or ";").
 func isFellowshipEscapeCommand(command string) bool {
 	trimmed := strings.TrimSpace(command)
 	if trimmed == "" ||
@@ -69,13 +68,6 @@ func isFellowshipEscapeCommand(command string) bool {
 	}
 	// Accept bare "fellowship" or any path ending in "/fellowship".
 	bin := fields[0]
-	if bin != "fellowship" && !strings.HasSuffix(bin, "/fellowship") {
-		return false
-	}
-	if len(fields) >= 3 && fields[1] == "gate" &&
-		(fields[2] == "reject" || fields[2] == "approve") {
-		return true
-	}
-	return fields[1] == "init"
+	return bin == "fellowship" || strings.HasSuffix(bin, "/fellowship")
 }
 

--- a/cli/internal/hooks/guard_test.go
+++ b/cli/internal/hooks/guard_test.go
@@ -120,7 +120,7 @@ func TestGateGuard_HeldTakesPriorityOverGatePending(t *testing.T) {
 	}
 }
 
-func TestGateGuard_AllowsAllFellowshipCommandsWhenPending(t *testing.T) {
+func TestGateGuard_AllowsAllowlistedFellowshipCommandsWhenPending(t *testing.T) {
 	s := &state.State{Phase: "Research", GatePending: true}
 	for _, cmd := range []string{
 		"fellowship gate reject",
@@ -131,13 +131,34 @@ func TestGateGuard_AllowsAllFellowshipCommandsWhenPending(t *testing.T) {
 		"fellowship autopsy infer --dir /tmp/worktree",
 		"fellowship errand list --dir .",
 		"fellowship status --json",
+		"fellowship eagles --json",
+		"fellowship tome show",
+		"fellowship herald --json",
+		"fellowship version",
 		"~/.claude/fellowship/bin/fellowship gate reject",
 		"/usr/local/bin/fellowship eagles",
 	} {
 		input := &HookInput{ToolInput: ToolInput{Command: cmd}}
 		result := GateGuard(s, input)
 		if result.Block {
-			t.Errorf("fellowship command should be allowed through gate_pending, cmd=%q got: %s", cmd, result.Message)
+			t.Errorf("allowlisted fellowship command should be allowed through gate_pending, cmd=%q got: %s", cmd, result.Message)
+		}
+	}
+}
+
+func TestGateGuard_BlocksNonAllowlistedFellowshipCommandsWhenPending(t *testing.T) {
+	s := &state.State{Phase: "Research", GatePending: true}
+	for _, cmd := range []string{
+		"fellowship state update-quest --name quest-1 --status completed",
+		"fellowship hold --dir /tmp/worktree",
+		"fellowship unhold --dir /tmp/worktree",
+		"fellowship dashboard",
+		"fellowship company approve foo",
+	} {
+		input := &HookInput{ToolInput: ToolInput{Command: cmd}}
+		result := GateGuard(s, input)
+		if !result.Block {
+			t.Errorf("non-allowlisted fellowship command should be blocked during gate_pending, cmd=%q", cmd)
 		}
 	}
 }

--- a/cli/internal/hooks/guard_test.go
+++ b/cli/internal/hooks/guard_test.go
@@ -120,27 +120,25 @@ func TestGateGuard_HeldTakesPriorityOverGatePending(t *testing.T) {
 	}
 }
 
-func TestGateGuard_AllowsFellowshipGateRejectWhenPending(t *testing.T) {
+func TestGateGuard_AllowsAllFellowshipCommandsWhenPending(t *testing.T) {
 	s := &state.State{Phase: "Research", GatePending: true}
 	for _, cmd := range []string{
-		"~/.claude/fellowship/bin/fellowship gate reject",
 		"fellowship gate reject",
-		"/usr/local/bin/fellowship gate reject",
+		"fellowship gate approve",
+		"fellowship init",
+		"fellowship autopsy create --dir /tmp/repo",
+		"fellowship autopsy scan --dir /tmp/repo --modules auth",
+		"fellowship autopsy infer --dir /tmp/worktree",
+		"fellowship errand list --dir .",
+		"fellowship status --json",
+		"~/.claude/fellowship/bin/fellowship gate reject",
+		"/usr/local/bin/fellowship eagles",
 	} {
 		input := &HookInput{ToolInput: ToolInput{Command: cmd}}
 		result := GateGuard(s, input)
 		if result.Block {
-			t.Errorf("fellowship gate reject should be allowed through gate_pending, cmd=%q got: %s", cmd, result.Message)
+			t.Errorf("fellowship command should be allowed through gate_pending, cmd=%q got: %s", cmd, result.Message)
 		}
-	}
-}
-
-func TestGateGuard_AllowsFellowshipInitWhenPending(t *testing.T) {
-	s := &state.State{Phase: "Implement", GatePending: true}
-	input := &HookInput{ToolInput: ToolInput{Command: "~/.claude/fellowship/bin/fellowship init"}}
-	result := GateGuard(s, input)
-	if result.Block {
-		t.Errorf("fellowship init should be allowed through gate_pending: %s", result.Message)
 	}
 }
 

--- a/plugin/commands/rekindle.md
+++ b/plugin/commands/rekindle.md
@@ -67,7 +67,7 @@ On user confirmation, transition into Gandalf coordinator mode:
 1. **Load config:** Read `~/.claude/fellowship.json` if it exists (same as `/fellowship`)
 2. **Create team:** `TeamCreate` with name `fellowship-{timestamp}`
 3. **Write fellowship state:** Write `.fellowship/fellowship-state.json` with recovered quest list (same as `/fellowship` startup)
-4. **Write autopsies for dead quests:** Before respawning, run `fellowship autopsy infer --dir <worktree> --repo <main_repo>` for each quest classified as `zombie` or `stale`. This preserves failure knowledge from the crashed session for future quests to learn from.
+4. **Write autopsies for dead quests:** Before respawning, run `~/.claude/fellowship/bin/fellowship autopsy infer --dir <worktree> --repo <main_repo>` for each quest classified as `stale`. This preserves failure knowledge from the crashed session for future quests to learn from.
 5. **For each non-complete quest:**
    a. `TaskCreate` with the original task description (from `fellowship-state.json` or inferred from quest name)
    b. Spawn a quest runner teammate with the **resume spawn prompt** (see below)

--- a/plugin/commands/rekindle.md
+++ b/plugin/commands/rekindle.md
@@ -67,7 +67,8 @@ On user confirmation, transition into Gandalf coordinator mode:
 1. **Load config:** Read `~/.claude/fellowship.json` if it exists (same as `/fellowship`)
 2. **Create team:** `TeamCreate` with name `fellowship-{timestamp}`
 3. **Write fellowship state:** Write `.fellowship/fellowship-state.json` with recovered quest list (same as `/fellowship` startup)
-4. **For each non-complete quest:**
+4. **Write autopsies for dead quests:** Before respawning, run `fellowship autopsy infer --dir <worktree> --repo <main_repo>` for each quest classified as `zombie` or `stale`. This preserves failure knowledge from the crashed session for future quests to learn from.
+5. **For each non-complete quest:**
    a. `TaskCreate` with the original task description (from `fellowship-state.json` or inferred from quest name)
    b. Spawn a quest runner teammate with the **resume spawn prompt** (see below)
 6. **Enter Gandalf coordinator loop** — same behavior as `/fellowship` (gate handling, status reports, user commands)

--- a/plugin/skills/fellowship/SKILL.md
+++ b/plugin/skills/fellowship/SKILL.md
@@ -260,7 +260,11 @@ Keep it brief — one line, not a monologue. Functional information always comes
 
 ## Edge Cases
 
-- **Quest fails:** Report to user with context (which phase, what went wrong). Offer to respawn. Worktree is preserved.
+- **Quest fails:** Report to user with context (which phase, what went wrong). Before respawning, write an autopsy to preserve failure knowledge for future quests:
+  ```bash
+  fellowship autopsy infer --dir <worktree_path> --repo <main_repo>
+  ```
+  This reconstructs a best-effort failure record from the quest's tome, herald, and eagles data. Then offer to respawn. Worktree is preserved.
   - **Respawn procedure:** Spawn a new teammate with the same task description, but add to the spawn prompt: `"You are resuming a failed quest. Your working directory is already set to the existing worktree at {worktree_path}. Skip worktree creation in quest Phase 0 — you're already isolated. Check .fellowship/checkpoint.md for a checkpoint from the previous attempt."` Set the new teammate's working directory to the failed quest's worktree path.
 - **Direct teammate access:** Through Gandalf ("tell quest-2 to skip the logger refactor") or direct via Shift+Down to message the teammate.
 - **Session death:** Worktrees survive but coordination is lost. To resume: start a new fellowship, use respawn procedure for each incomplete quest. Each worktree's `.fellowship/checkpoint.md` has the last known state. For manual recovery: `~/.claude/fellowship/bin/fellowship gate reject --dir <worktree>`

--- a/plugin/skills/quest/SKILL.md
+++ b/plugin/skills/quest/SKILL.md
@@ -183,10 +183,15 @@ The same hard gate requirements apply — validation mode doesn't lower the bar,
 #### Standard Research
 
 **Actions:**
-1. If entering an unfamiliar area, invoke `/gather-lore` to extract conventions from reference files
-2. Use Explore agents (Task tool, subagent_type=Explore) to scan relevant code paths
-3. Read key files identified in the Session Context
-4. Document findings: how the current system works, constraints, edge cases
+1. **Scan autopsies:** If running as a fellowship teammate, scan for prior failure records that may be relevant to this quest:
+   ```bash
+   fellowship autopsy scan --dir <main_repo> --files "<target_files>" --modules "<target_modules>"
+   ```
+   If matches are found, incorporate their warnings into your research findings — these are hard-won lessons from previous quests that failed in the same area.
+2. If entering an unfamiliar area, invoke `/gather-lore` to extract conventions from reference files
+3. Use Explore agents (Task tool, subagent_type=Explore) to scan relevant code paths
+4. Read key files identified in the Session Context
+5. Document findings: how the current system works, constraints, edge cases
 
 **Hard gate — Research must produce:**
 - [ ] Key files identified with specific line ranges
@@ -251,9 +256,13 @@ Trigger recovery when any of these occur:
 Recovery procedure:
 1. **Stop implementing.** Commit what works so far — don't discard partial progress.
 2. **Document what went wrong.** Be specific: which step failed, what was discovered, why the plan doesn't hold.
-3. **Return to Phase 2 (Plan).** Invoke `/lembas` with phase "Implement (partial)" to compact, then re-enter plan mode with the new information. Revise only the affected steps — don't replan from scratch.
-4. **Get user approval** on the revised plan before resuming implementation.
-5. If running as a fellowship teammate, message the lead with the blocker before replanning.
+3. **Write autopsy:** If running as a fellowship teammate, record the failure for future quests:
+   ```bash
+   echo '{"quest":"<quest_name>","task":"<task>","phase":"Implement","trigger":"recovery","files":["<affected_files>"],"modules":["<affected_modules>"],"what_failed":"<specific description>","resolution":"<what you learned or changed>","tags":["<relevant_tags>"]}' | fellowship autopsy create --dir <main_repo>
+   ```
+4. **Return to Phase 2 (Plan).** Invoke `/lembas` with phase "Implement (partial)" to compact, then re-enter plan mode with the new information. Revise only the affected steps — don't replan from scratch.
+5. **Get user approval** on the revised plan before resuming implementation.
+6. If running as a fellowship teammate, message the lead with the blocker before replanning.
 
 **Transition:** Invoke `/lembas` with phase "Implement" before moving to Adversarial Review.
 

--- a/plugin/skills/retro/SKILL.md
+++ b/plugin/skills/retro/SKILL.md
@@ -39,6 +39,8 @@ For each quest worktree listed in `fellowship-state.json`:
 
 5. **Palantir alerts:** Read `palantir-alerts.jsonl` from the resolved data directory at the git root if it exists. Each line is a JSON object with `timestamp`, `type` (stuck/drift/conflict/health), `quests`, and `detail`.
 
+6. **Autopsies:** Scan the `autopsies/` subdirectory within the resolved data directory. Each `.json` file is a structured failure record with `quest`, `phase`, `trigger`, `files`, `modules`, `what_failed`, and `resolution` fields. Collect all entries.
+
 ### Step 3: Analyze
 
 Compute the following from collected data:
@@ -60,6 +62,11 @@ Compute the following from collected data:
 - Count by type (stuck, drift, conflict, health)
 - Which quests were flagged most frequently
 
+**Autopsy patterns:**
+- Count autopsies by trigger (recovery, rejection, abandonment)
+- Modules/files with multiple autopsies (hot spots for failure)
+- Common tags across autopsies (recurring themes)
+
 ### Step 4: Present Results
 
 Output the analysis in this format:
@@ -70,6 +77,7 @@ Fellowship Retrospective: {fellowship_name}
 Quests: {completed} completed, {failed} failed
 Gates: {total} total, {rejected} rejected ({rejection_details})
 Palantir alerts: {alert_summary}
+Autopsies: {autopsy_count} ({trigger_breakdown})
 
 Observations:
 - {observation_1}
@@ -87,6 +95,8 @@ Recommendations:
 - "quest-ui-login spent longest in Research — task may have been under-specified"
 - "No warden violations — conventions well-established"
 - "2 file conflict alerts — consider splitting shared files across quests"
+- "auth module has 4 autopsies — consider documenting its quirks in CLAUDE.md"
+- "3 recovery autopsies in Implement — plans may need more detail"
 
 **Recommendation examples:**
 - Auto-approve phases with 0% rejection rate


### PR DESCRIPTION
## Summary

- Adds structured failure records (autopsies) that persist in `.fellowship/autopsies/` so future quests learn from past mistakes
- Three CLI commands: `autopsy create` (JSON stdin), `autopsy scan` (match by files/modules/tags), `autopsy infer` (reconstruct from worktree signals)
- Simplifies gate guard to allow all `fellowship` CLI commands through the gate, not just `gate approve/reject/init`
- Integrates autopsy scan into quest Research phase and autopsy write into Implement recovery
- Adds `autopsy infer` to Gandalf's dead-quest handling and rekindle recovery flow
- Adds autopsy aggregation to `/retro` retrospective analysis
- Configurable expiry (default 90 days) via `autopsy.expiryDays` in `~/.claude/fellowship.json`

Closes #67

## Test plan

- [x] 22 unit tests covering create, scan, infer, expiry pruning, matching, config reading
- [x] Updated guard tests verify all fellowship commands pass through gate
- [x] Full test suite passes (`go test ./...`)
- [x] Binary compiles cleanly (`go build ./cmd/fellowship/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an autopsy system to record, scan, and infer quest failures with CLI commands: autopsy create, autopsy scan, autopsy infer. Added default expiry (90 days) and user-configurable expiry.

* **Behavior Changes**
  * Gate-pending now allows a broader set of safe fellowship subcommands; CLI help updated to include autopsy commands.

* **Documentation**
  * Integrated autopsy steps into recovery, skills, and retrospective workflows.

* **Tests**
  * Added comprehensive tests for autopsy flows, expiry config, inference, and gate behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->