### PR TITLE
feat: Gandalf hardening — CWD guard and gate enrichment

### DIFF
--- a/cli/cmd/fellowship/main.go
+++ b/cli/cmd/fellowship/main.go
@@ -240,7 +240,18 @@ func runHook(name string) int {
 		fmt.Fprintf(os.Stderr, "fellowship: %v\n", err)
 		return 2
 	}
+	// Lead session (no state file): only the CWD guard applies.
 	if statePath == "" {
+		if name == "gate-guard" {
+			input, err := hooks.ParseInput(os.Stdin)
+			if err != nil {
+				input = &hooks.HookInput{}
+			}
+			if result := hooks.WorktreeGuard(input); result.Block {
+				fmt.Fprintln(os.Stderr, result.Message)
+				return 2
+			}
+		}
 		return 0
 	}
 

--- a/cli/cmd/fellowship/main.go
+++ b/cli/cmd/fellowship/main.go
@@ -311,6 +311,7 @@ func runHook(name string) int {
 
 	// Mutating hooks: use WithLock for atomic load→mutate→save.
 	var result hooks.HookResult
+	var gateSubmitEnrich bool
 	if err := state.WithLock(statePath, func(s *state.State) error {
 		questName := s.QuestName
 		if questName == "" {
@@ -323,6 +324,7 @@ func runHook(name string) int {
 			sr := hooks.GateSubmit(s, input)
 			result = hooks.HookResult{Block: sr.Block, Message: sr.Message}
 			if sr.StateChanged && !sr.Block {
+				gateSubmitEnrich = true
 				tomePath := filepath.Join(filepath.Dir(statePath), "quest-tome.json")
 				hooks.RecordGateSubmitted(tomePath, prevPhase, s.Phase != prevPhase)
 				herald.Announce(dir, herald.Tiding{
@@ -374,8 +376,22 @@ func runHook(name string) int {
 	}
 
 	if result.Block {
+		if name == "gate-submit" {
+			out := hooks.NewDenyOutput(result.Message)
+			json.NewEncoder(os.Stdout).Encode(out)
+			return 0 // exit 0 with JSON deny — Claude Code reads the JSON
+		}
 		fmt.Fprintln(os.Stderr, result.Message)
 		return 2
+	}
+
+	if gateSubmitEnrich {
+		enrichment := hooks.GatherEnrichment(dir)
+		if enrichment != "" {
+			enrichedContent := input.ToolInput.Content + enrichment
+			out := hooks.NewAllowOutput(map[string]string{"content": enrichedContent})
+			json.NewEncoder(os.Stdout).Encode(out)
+		}
 	}
 	return 0
 }

--- a/cli/internal/hooks/enrich.go
+++ b/cli/internal/hooks/enrich.go
@@ -73,7 +73,7 @@ func gatherPhaseDuration(dir string) string {
 		if tidings[i].Type == herald.GateApproved {
 			ts, err := time.Parse(time.RFC3339, tidings[i].Timestamp)
 			if err != nil {
-				return ""
+				continue
 			}
 			dur := time.Since(ts)
 			if dur < time.Minute {

--- a/cli/internal/hooks/enrich.go
+++ b/cli/internal/hooks/enrich.go
@@ -1,6 +1,7 @@
 package hooks
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 	"regexp"
@@ -51,10 +52,12 @@ func gatherFilesTouched(dir string) string {
 }
 
 func gatherDiffStats(dir string) string {
-	cmd := exec.Command("git", "diff", "--stat")
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "git", "diff", "--stat")
 	cmd.Dir = dir
 	out, err := cmd.Output()
-	if err != nil {
+	if err != nil || ctx.Err() != nil {
 		return ""
 	}
 	return parseDiffStats(string(out))

--- a/cli/internal/hooks/enrich.go
+++ b/cli/internal/hooks/enrich.go
@@ -1,0 +1,144 @@
+package hooks
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/justinjdev/fellowship/cli/internal/errand"
+	"github.com/justinjdev/fellowship/cli/internal/herald"
+	"github.com/justinjdev/fellowship/cli/internal/tome"
+)
+
+// GatherEnrichment collects quest metrics from the worktree directory
+// and returns a formatted enrichment block to append to gate messages.
+// Returns empty string if no data sources are available.
+func GatherEnrichment(dir string) string {
+	errandStr := gatherErrandProgress(dir)
+	filesStr := gatherFilesTouched(dir)
+	diffStr := gatherDiffStats(dir)
+	durationStr := gatherPhaseDuration(dir)
+
+	block := buildEnrichmentBlock(errandStr, filesStr, diffStr, durationStr)
+	return block
+}
+
+func gatherErrandProgress(dir string) string {
+	path, err := errand.FindErrands(dir)
+	if err != nil || path == "" {
+		return ""
+	}
+	el, err := errand.Load(path)
+	if err != nil {
+		return ""
+	}
+	done, total := errand.Progress(el)
+	return formatErrandProgress(done, total)
+}
+
+func gatherFilesTouched(dir string) string {
+	path, err := tome.FindTome(dir)
+	if err != nil || path == "" {
+		return ""
+	}
+	t, err := tome.Load(path)
+	if err != nil {
+		return ""
+	}
+	return formatFilesTouched(t.FilesTouched)
+}
+
+func gatherDiffStats(dir string) string {
+	cmd := exec.Command("git", "diff", "--stat")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return parseDiffStats(string(out))
+}
+
+func gatherPhaseDuration(dir string) string {
+	tidings, err := herald.Read(dir, 0)
+	if err != nil || len(tidings) == 0 {
+		return ""
+	}
+	// Find the most recent gate_approved tiding (marks phase entry).
+	for i := len(tidings) - 1; i >= 0; i-- {
+		if tidings[i].Type == herald.GateApproved {
+			ts, err := time.Parse(time.RFC3339, tidings[i].Timestamp)
+			if err != nil {
+				return ""
+			}
+			dur := time.Since(ts)
+			if dur < time.Minute {
+				return fmt.Sprintf("%ds", int(dur.Seconds()))
+			}
+			return fmt.Sprintf("%dm", int(dur.Minutes()))
+		}
+	}
+	return ""
+}
+
+func formatErrandProgress(done, total int) string {
+	if total == 0 {
+		return "no errands"
+	}
+	return fmt.Sprintf("%d/%d done", done, total)
+}
+
+func formatFilesTouched(files []string) string {
+	if len(files) == 0 {
+		return "none"
+	}
+	const maxShow = 5
+	if len(files) <= maxShow {
+		return fmt.Sprintf("%d (%s)", len(files), strings.Join(files, ", "))
+	}
+	return fmt.Sprintf("%d (%s, ...)", len(files), strings.Join(files[:maxShow], ", "))
+}
+
+var diffSummaryRe = regexp.MustCompile(`(\d+) files? changed(?:, (\d+) insertions?\(\+\))?(?:, (\d+) deletions?\(-\))?`)
+
+func parseDiffStats(output string) string {
+	output = strings.TrimSpace(output)
+	if output == "" {
+		return "no changes"
+	}
+	m := diffSummaryRe.FindStringSubmatch(output)
+	if m == nil {
+		return "no changes"
+	}
+	files := m[1]
+	ins := m[2]
+	del := m[3]
+	if ins == "" {
+		ins = "0"
+	}
+	if del == "" {
+		del = "0"
+	}
+	return fmt.Sprintf("+%s -%s across %s files", ins, del, files)
+}
+
+func buildEnrichmentBlock(errands, files, diff, duration string) string {
+	var lines []string
+	if errands != "" {
+		lines = append(lines, fmt.Sprintf("- **Errands:** %s", errands))
+	}
+	if files != "" {
+		lines = append(lines, fmt.Sprintf("- **Files touched:** %s", files))
+	}
+	if diff != "" {
+		lines = append(lines, fmt.Sprintf("- **Diff:** %s", diff))
+	}
+	if duration != "" {
+		lines = append(lines, fmt.Sprintf("- **Phase duration:** %s", duration))
+	}
+	if len(lines) == 0 {
+		return ""
+	}
+	return "\n\n---\n## Gate Context (auto-generated)\n" + strings.Join(lines, "\n")
+}

--- a/cli/internal/hooks/enrich_test.go
+++ b/cli/internal/hooks/enrich_test.go
@@ -1,0 +1,115 @@
+package hooks
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGatherEnrichment_EmptyDir(t *testing.T) {
+	// Non-existent directory should return empty string (graceful fallback)
+	result := GatherEnrichment("/nonexistent/path")
+	if result != "" {
+		t.Errorf("expected empty enrichment for missing dir, got: %q", result)
+	}
+}
+
+func TestFormatErrandProgress_WithErrands(t *testing.T) {
+	got := formatErrandProgress(3, 5)
+	if got != "3/5 done" {
+		t.Errorf("got %q, want %q", got, "3/5 done")
+	}
+}
+
+func TestFormatErrandProgress_AllDone(t *testing.T) {
+	got := formatErrandProgress(5, 5)
+	if got != "5/5 done" {
+		t.Errorf("got %q, want %q", got, "5/5 done")
+	}
+}
+
+func TestFormatErrandProgress_None(t *testing.T) {
+	got := formatErrandProgress(0, 0)
+	if got != "no errands" {
+		t.Errorf("got %q, want %q", got, "no errands")
+	}
+}
+
+func TestFormatFilesTouched_Multiple(t *testing.T) {
+	files := []string{"src/main.go", "src/auth.go", "src/db.go"}
+	got := formatFilesTouched(files)
+	if !strings.HasPrefix(got, "3") {
+		t.Errorf("should start with count, got: %q", got)
+	}
+	if !strings.Contains(got, "src/main.go") {
+		t.Errorf("should contain file names, got: %q", got)
+	}
+}
+
+func TestFormatFilesTouched_Empty(t *testing.T) {
+	got := formatFilesTouched(nil)
+	if got != "none" {
+		t.Errorf("got %q, want %q", got, "none")
+	}
+}
+
+func TestFormatFilesTouched_TruncatesLongList(t *testing.T) {
+	files := make([]string, 20)
+	for i := range files {
+		files[i] = "file" + string(rune('a'+i)) + ".go"
+	}
+	got := formatFilesTouched(files)
+	if !strings.Contains(got, "...") {
+		t.Errorf("should truncate long list, got: %q", got)
+	}
+}
+
+func TestParseDiffStats(t *testing.T) {
+	// Typical git diff --stat output
+	output := ` src/main.go   | 10 ++++------
+ src/auth.go   |  5 +++++
+ 2 files changed, 9 insertions(+), 6 deletions(-)
+`
+	got := parseDiffStats(output)
+	if !strings.Contains(got, "+9") {
+		t.Errorf("should contain insertions, got: %q", got)
+	}
+	if !strings.Contains(got, "-6") {
+		t.Errorf("should contain deletions, got: %q", got)
+	}
+	if !strings.Contains(got, "2 files") {
+		t.Errorf("should contain file count, got: %q", got)
+	}
+}
+
+func TestParseDiffStats_Empty(t *testing.T) {
+	got := parseDiffStats("")
+	if got != "no changes" {
+		t.Errorf("got %q, want %q", got, "no changes")
+	}
+}
+
+func TestBuildEnrichmentBlock(t *testing.T) {
+	block := buildEnrichmentBlock("3/5 done", "2 (src/main.go, src/auth.go)", "+10 -5 across 2 files", "8m")
+	if !strings.Contains(block, "Gate Context") {
+		t.Error("should contain header")
+	}
+	if !strings.Contains(block, "3/5 done") {
+		t.Error("should contain errand progress")
+	}
+	if !strings.Contains(block, "+10 -5") {
+		t.Error("should contain diff stats")
+	}
+}
+
+func TestBuildEnrichmentBlock_SkipsMissingFields(t *testing.T) {
+	block := buildEnrichmentBlock("", "none", "", "")
+	if strings.Contains(block, "Errands") {
+		t.Error("should skip empty errands line")
+	}
+	if strings.Contains(block, "Diff") {
+		t.Error("should skip empty diff line")
+	}
+	if strings.Contains(block, "Phase duration") {
+		t.Error("should skip empty duration line")
+	}
+}

--- a/cli/internal/hooks/guard.go
+++ b/cli/internal/hooks/guard.go
@@ -2,6 +2,7 @@ package hooks
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/justinjdev/fellowship/cli/internal/datadir"
@@ -47,6 +48,61 @@ func GateGuard(s *state.State, input *HookInput) HookResult {
 	}
 
 	return HookResult{}
+}
+
+// WorktreeGuard blocks the lead session from cd'ing into quest worktrees.
+// It is called when no quest state file exists (indicating this is the lead session).
+// Scoped commands (cd path && ...) are allowed since CWD doesn't persist between
+// Bash tool calls.
+func WorktreeGuard(input *HookInput) HookResult {
+	if input == nil {
+		return HookResult{}
+	}
+	cmd := strings.TrimSpace(input.ToolInput.Command)
+	if cmd == "" {
+		return HookResult{}
+	}
+
+	if isWorktreeCD(cmd) {
+		return HookResult{
+			Block:   true,
+			Message: "Gandalf must not cd into quest worktrees. Use --dir <path> for fellowship commands, or absolute paths for reading files.",
+		}
+	}
+	return HookResult{}
+}
+
+// isWorktreeCD detects bare "cd <worktree>" or "pushd <worktree>" commands.
+// Scoped commands like "cd <worktree> && <cmd>" are allowed.
+func isWorktreeCD(command string) bool {
+	fields := strings.Fields(command)
+	if len(fields) < 2 {
+		return false
+	}
+
+	verb := fields[0]
+	if verb != "cd" && verb != "pushd" {
+		return false
+	}
+
+	target := fields[1]
+	if !isWorktreePath(target) {
+		return false
+	}
+
+	// If there's anything after the target, it's a scoped command — allow it.
+	// e.g., "cd path && git log" has fields[2] == "&&"
+	if len(fields) > 2 {
+		return false
+	}
+	return true
+}
+
+// isWorktreePath checks if a path leads into the worktree directory.
+func isWorktreePath(path string) bool {
+	normalized := filepath.ToSlash(filepath.Clean(path))
+	return strings.Contains(normalized, "/.claude/worktrees/") ||
+		strings.HasPrefix(normalized, ".claude/worktrees/")
 }
 
 // isFellowshipEscapeCommand returns true for fellowship CLI commands that are

--- a/cli/internal/hooks/guard.go
+++ b/cli/internal/hooks/guard.go
@@ -85,7 +85,8 @@ func isWorktreeCD(command string) bool {
 		return false
 	}
 
-	target := fields[1]
+	target := strings.Trim(fields[1], `"'`)
+	target = strings.TrimSuffix(target, ";")
 	if !isWorktreePath(target) {
 		return false
 	}
@@ -98,11 +99,13 @@ func isWorktreeCD(command string) bool {
 	return true
 }
 
-// isWorktreePath checks if a path leads into the worktree directory.
+// isWorktreePath checks if a path leads into or is the worktree directory.
 func isWorktreePath(path string) bool {
-	normalized := filepath.ToSlash(filepath.Clean(path))
-	return strings.Contains(normalized, "/.claude/worktrees/") ||
-		strings.HasPrefix(normalized, ".claude/worktrees/")
+	normalized := strings.TrimSuffix(filepath.ToSlash(filepath.Clean(path)), "/")
+	return normalized == ".claude/worktrees" ||
+		strings.HasPrefix(normalized, ".claude/worktrees/") ||
+		strings.HasSuffix(normalized, "/.claude/worktrees") ||
+		strings.Contains(normalized, "/.claude/worktrees/")
 }
 
 // isFellowshipEscapeCommand returns true for fellowship CLI commands that are

--- a/cli/internal/hooks/guard_test.go
+++ b/cli/internal/hooks/guard_test.go
@@ -255,6 +255,41 @@ func TestWorktreeGuard_AllowsNonCDCommands(t *testing.T) {
 	}
 }
 
+func TestWorktreeGuard_BlocksWorktreeRoot(t *testing.T) {
+	for _, cmd := range []string{
+		"cd .claude/worktrees",
+		"cd /home/user/repo/.claude/worktrees",
+		"pushd .claude/worktrees",
+	} {
+		input := &HookInput{ToolInput: ToolInput{Command: cmd}}
+		result := WorktreeGuard(input)
+		if !result.Block {
+			t.Errorf("should block cd into worktree root, cmd=%q", cmd)
+		}
+	}
+}
+
+func TestWorktreeGuard_BlocksQuotedTarget(t *testing.T) {
+	for _, cmd := range []string{
+		`cd ".claude/worktrees/quest-1"`,
+		`cd '.claude/worktrees/quest-1'`,
+	} {
+		input := &HookInput{ToolInput: ToolInput{Command: cmd}}
+		result := WorktreeGuard(input)
+		if !result.Block {
+			t.Errorf("should block quoted cd into worktree, cmd=%q", cmd)
+		}
+	}
+}
+
+func TestWorktreeGuard_BlocksTrailingSemicolon(t *testing.T) {
+	input := &HookInput{ToolInput: ToolInput{Command: "cd .claude/worktrees/quest-1;"}}
+	result := WorktreeGuard(input)
+	if !result.Block {
+		t.Errorf("should block cd with trailing semicolon")
+	}
+}
+
 func TestWorktreeGuard_AllowsEmptyCommand(t *testing.T) {
 	input := &HookInput{ToolInput: ToolInput{Command: ""}}
 	result := WorktreeGuard(input)

--- a/cli/internal/hooks/guard_test.go
+++ b/cli/internal/hooks/guard_test.go
@@ -190,3 +190,82 @@ func TestGateGuard_HeldBlocksFellowshipEscapeCommands(t *testing.T) {
 		t.Error("held state should block even fellowship escape commands")
 	}
 }
+
+func TestWorktreeGuard_BlocksBareCD(t *testing.T) {
+	for _, cmd := range []string{
+		"cd .claude/worktrees/quest-1",
+		"cd /home/user/repo/.claude/worktrees/quest-1",
+		"cd .claude/worktrees/quest-1/src",
+	} {
+		input := &HookInput{ToolInput: ToolInput{Command: cmd}}
+		result := WorktreeGuard(input)
+		if !result.Block {
+			t.Errorf("should block bare cd into worktree, cmd=%q", cmd)
+		}
+	}
+}
+
+func TestWorktreeGuard_BlocksPushd(t *testing.T) {
+	input := &HookInput{ToolInput: ToolInput{Command: "pushd .claude/worktrees/quest-1"}}
+	result := WorktreeGuard(input)
+	if !result.Block {
+		t.Error("should block pushd into worktree")
+	}
+}
+
+func TestWorktreeGuard_AllowsScopedCD(t *testing.T) {
+	for _, cmd := range []string{
+		"cd .claude/worktrees/quest-1 && git log",
+		"cd .claude/worktrees/quest-1 && go test ./...",
+		"cd .claude/worktrees/quest-1 || echo fail",
+	} {
+		input := &HookInput{ToolInput: ToolInput{Command: cmd}}
+		result := WorktreeGuard(input)
+		if result.Block {
+			t.Errorf("should allow scoped cd, cmd=%q", cmd)
+		}
+	}
+}
+
+func TestWorktreeGuard_AllowsNonWorktreeCD(t *testing.T) {
+	for _, cmd := range []string{
+		"cd /tmp",
+		"cd src/auth",
+		"cd ..",
+	} {
+		input := &HookInput{ToolInput: ToolInput{Command: cmd}}
+		result := WorktreeGuard(input)
+		if result.Block {
+			t.Errorf("should allow cd to non-worktree path, cmd=%q", cmd)
+		}
+	}
+}
+
+func TestWorktreeGuard_AllowsNonCDCommands(t *testing.T) {
+	for _, cmd := range []string{
+		"cat .claude/worktrees/quest-1/src/main.go",
+		"ls .claude/worktrees/quest-1",
+		"grep -r foo .claude/worktrees/quest-1",
+	} {
+		input := &HookInput{ToolInput: ToolInput{Command: cmd}}
+		result := WorktreeGuard(input)
+		if result.Block {
+			t.Errorf("should allow non-cd commands referencing worktrees, cmd=%q", cmd)
+		}
+	}
+}
+
+func TestWorktreeGuard_AllowsEmptyCommand(t *testing.T) {
+	input := &HookInput{ToolInput: ToolInput{Command: ""}}
+	result := WorktreeGuard(input)
+	if result.Block {
+		t.Error("should allow empty command")
+	}
+}
+
+func TestWorktreeGuard_AllowsNilInput(t *testing.T) {
+	result := WorktreeGuard(nil)
+	if result.Block {
+		t.Error("should allow nil input")
+	}
+}

--- a/cli/internal/hooks/submit.go
+++ b/cli/internal/hooks/submit.go
@@ -80,6 +80,42 @@ func RecordGateSubmitted(tomePath string, phase string, autoApproved bool) {
 	tome.Save(tomePath, c)
 }
 
+// HookSpecificOutput is the JSON structure Claude Code expects from
+// PreToolUse hooks when they need to modify tool input.
+type HookSpecificOutput struct {
+	HSO hookSpecificOutputInner `json:"hookSpecificOutput"`
+}
+
+type hookSpecificOutputInner struct {
+	HookEventName            string            `json:"hookEventName"`
+	PermissionDecision       string            `json:"permissionDecision"`
+	PermissionDecisionReason string            `json:"permissionDecisionReason,omitempty"`
+	UpdatedInput             map[string]string `json:"updatedInput,omitempty"`
+}
+
+// NewAllowOutput returns a HookSpecificOutput that allows the tool call
+// with optional input mutation.
+func NewAllowOutput(updatedInput map[string]string) HookSpecificOutput {
+	return HookSpecificOutput{
+		HSO: hookSpecificOutputInner{
+			HookEventName:      "PreToolUse",
+			PermissionDecision: "allow",
+			UpdatedInput:       updatedInput,
+		},
+	}
+}
+
+// NewDenyOutput returns a HookSpecificOutput that blocks the tool call.
+func NewDenyOutput(reason string) HookSpecificOutput {
+	return HookSpecificOutput{
+		HSO: hookSpecificOutputInner{
+			HookEventName:            "PreToolUse",
+			PermissionDecision:       "deny",
+			PermissionDecisionReason: reason,
+		},
+	}
+}
+
 func hasGateMarker(content string) bool {
 	for line := range strings.SplitSeq(content, "\n") {
 		if strings.HasPrefix(line, "[GATE]") {

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -29,7 +29,7 @@
           {
             "type": "command",
             "command": "${HOME}/.claude/fellowship/bin/fellowship hook gate-submit",
-            "timeout": 5
+            "timeout": 10
           }
         ]
       },

--- a/plugin/skills/quest/SKILL.md
+++ b/plugin/skills/quest/SKILL.md
@@ -63,7 +63,23 @@ Phase 5: Complete ───→ finishing-a-development-branch
 When running as a fellowship teammate (indicated by the spawn prompt), the gate prerequisite order at the end of each phase is:
 1. Run `/lembas` to compress context (hooks verify this)
 2. Update task metadata: `TaskUpdate(taskId: "<your_task_id>", metadata: {"phase": "<current_phase>"})` (hooks verify this)
-3. Send `[GATE]` message to the lead via SendMessage
+3. Send `[GATE]` message to the lead via SendMessage using this template:
+
+```
+[GATE] <phase> complete
+
+## Summary
+<2-3 sentences: what was done this phase, key decisions made>
+
+## Artifacts
+- <file:lines> — <what/why>
+
+## Risks
+<any concerns for the next phase, or "None">
+
+## Next Phase Needs
+<what the next phase should focus on>
+```
 
 Both steps 1 and 2 must complete before step 3 — the hooks will block gate submission otherwise. Valid phase names: Onboard, Research, Plan, Implement, Adversarial, Review, Complete.
 


### PR DESCRIPTION
## Summary
- **CWD Guard:** Adds `WorktreeGuard` that blocks the lead session (Gandalf) from bare `cd`/`pushd` into quest worktrees, preventing accidental CWD corruption. Scoped commands (`cd path && cmd`) are still allowed.
- **Structured gate template:** Quest skill now includes a gate submission template (Summary, Artifacts, Risks, Next Phase Needs) for consistent gate messages.
- **Gate enrichment:** The `gate-submit` hook now auto-appends quest metrics (errand progress, files touched, diff stats, phase duration) to gate messages via `hookSpecificOutput.updatedInput`.

## Test plan
- [ ] Unit tests for `WorktreeGuard` (7 test functions covering block/allow scenarios)
- [ ] Unit tests for enrichment helpers (format, parse, build functions)
- [ ] E2E: `fellowship hook gate-guard` blocks bare cd into worktrees (exit 2)
- [ ] E2E: `fellowship hook gate-guard` allows scoped cd and non-worktree cd (exit 0)
- [ ] Full `go test ./...` passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Blocks direct cd/pushd into quest worktrees and offers alternative guidance.
  * Gate submissions can include enriched context (errand progress, touched files, diff summary, phase timing) and may return updated input.

* **Updates**
  * Increased gate-submit timeout to improve enrichment gathering reliability.
  * Gate-submit responses now emit structured allow/deny JSON for clearer downstream handling and enriched allow output.

* **Tests**
  * Added comprehensive tests for worktree guard and enrichment utilities.

* **Documentation**
  * Gate submission instructions updated to a multi-section templated message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->