### PR TITLE
fix: light theme WCAG AA color contrast

### DIFF
--- a/site/src/lib/styles/theme.css
+++ b/site/src/lib/styles/theme.css
@@ -39,17 +39,17 @@
 	--color-text: #3d2b1f;
 	--color-text-secondary: #5a4a3a;
 	--color-heading: #6b4c1e;
-	--color-accent: #8b6914;
-	--color-accent-hover: #a07a1a;
+	--color-accent: #7a5a0e;
+	--color-accent-hover: #8b6914;
 	--color-border: #d4c4a0;
 	--color-code-bg: #efe3c0;
 	--color-link: #6b4c1e;
-	--color-link-hover: #8b6914;
-	--color-focus: #8b6914;
+	--color-link-hover: #7a5a0e;
+	--color-focus: #7a5a0e;
 	--color-surface: #fff8e7;
 	--color-error-bg: rgba(139, 37, 0, 0.08);
-	--color-scout: #4a8a9e;
-	--color-monitor: #7b6ea4;
+	--color-scout: #377080;
+	--color-monitor: #635599;
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary

- Darken light theme accent, scout, and monitor colors to meet WCAG AA contrast ratios (4.5:1 minimum for normal text)
- All three pairs were previously below 4.5:1; now all pass

| Color | Before | After | Contrast |
|-------|--------|-------|----------|
| accent | `#8b6914` (4.1:1) | `#7a5a0e` (5.1:1) | Pass |
| scout | `#4a8a9e` (3.3:1) | `#377080` (4.7:1) | Pass |
| monitor | `#7b6ea4` (3.4:1) | `#635599` (4.8:1) | Pass |

Dark theme was already compliant — no changes needed.

## Test plan

- [ ] Verify light theme text is readable on all pages
- [ ] Verify scout/monitor colors on how-it-works page are legible
- [ ] Verify link hover states still look distinct

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated light theme color palette for improved visual consistency and accessibility, including changes to accent colors, link hover states, focus indicators, and category-specific colors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->