### PR TITLE
fix(dashboard): complete stale socket guards, cross-platform shortcut, quest navigation

### DIFF
--- a/dashboard/src/lib/components/Shell.svelte
+++ b/dashboard/src/lib/components/Shell.svelte
@@ -9,7 +9,7 @@
 	let paletteOpen = $state(false);
 
 	function handleKeydown(e: KeyboardEvent) {
-		if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
+		if (e.key.toLowerCase() === 'k' && (e.metaKey || e.ctrlKey)) {
 			e.preventDefault();
 			paletteOpen = !paletteOpen;
 		}

--- a/dashboard/src/lib/stores/websocket.ts
+++ b/dashboard/src/lib/stores/websocket.ts
@@ -34,7 +34,7 @@ function getWSUrl(): string {
 }
 
 function connect() {
-	if (ws?.readyState === WebSocket.OPEN) return;
+	if (ws && (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING)) return;
 
 	let socket: WebSocket;
 	try {
@@ -59,10 +59,12 @@ function connect() {
 	};
 
 	socket.onerror = () => {
+		if (ws !== socket) return;
 		socket.close();
 	};
 
 	socket.onmessage = (event) => {
+		if (ws !== socket) return;
 		try {
 			const data: WSEvent = JSON.parse(event.data);
 			lastEvent.set(data);

--- a/dashboard/src/lib/stores/websocket.ts
+++ b/dashboard/src/lib/stores/websocket.ts
@@ -59,7 +59,6 @@ function connect() {
 	};
 
 	socket.onerror = () => {
-		if (ws !== socket) return;
 		socket.close();
 	};
 

--- a/dashboard/src/routes/quest/[id]/+page.svelte
+++ b/dashboard/src/routes/quest/[id]/+page.svelte
@@ -26,6 +26,15 @@
 
 	let loading = $state(false);
 
+	// Reset data when navigating between quests (component is reused)
+	$effect(() => {
+		questName;
+		dataLoaded = false;
+		loadFailed = false;
+		errandList = null;
+		tomeData = null;
+	});
+
 	$effect(() => {
 		if (quest && !dataLoaded && !loadFailed && !loading) {
 			loading = true;


### PR DESCRIPTION
## Summary
- Complete stale socket instance guards in websocket.ts — add `ws !== socket` check to `onmessage` handler and CONNECTING state check to prevent duplicate connections
- Normalize keyboard shortcut key check with `toLowerCase()` in Shell.svelte for cross-platform robustness
- Add reactive reset when navigating between quest detail pages to prevent stale data display

Addresses CodeRabbit review comments from PR #76.

## Test plan
- [ ] Verify Cmd+K and Ctrl+K both toggle command palette
- [ ] Verify websocket reconnection doesn't process messages from stale sockets
- [ ] Verify navigating between quest detail pages loads fresh data
- [ ] Verify `npm run check` passes in dashboard/

🤖 Generated with [Claude Code](https://claude.com/claude-code)