### PR TITLE
fix: enforce worktree isolation (fail-closed guard + lead cd-guard)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,60 +4,80 @@ Thanks for your interest in contributing to Fellowship — a Claude Code plugin 
 
 ## What This Repo Is
 
-Fellowship is a Claude Code plugin. Skills, agents, and docs are markdown. Gate enforcement hooks are bash scripts. There is no build system and no dependencies beyond `jq` (for hooks).
+Fellowship is a Claude Code plugin with two parts:
+
+- **Prompt layer** — skills, agents, and commands are pure markdown under `plugin/`. No runtime code.
+- **Enforcement layer** — gate enforcement, worktree isolation, and quest state live in a Go CLI (`cli/`). Claude Code hooks shell out to the `fellowship` binary, which reads the hook payload as JSON on stdin and signals allow/block via its exit code.
+
+The binary is built from `cli/` and distributed via GitHub releases (goreleaser on tag push). End users never build it — `plugin/hooks/scripts/ensure-binary.sh` downloads the matching release on first use (wired as a `SessionStart` hook), installing it at `~/.claude/fellowship/bin/fellowship`.
 
 ## Getting Started
 
 1. Clone the repo
-2. Test locally: `claude --plugin-dir .`
-3. Run hook tests: `./hooks/test-hooks.sh`
+2. Test the plugin locally: `claude --plugin-dir .`
+3. Build and test the CLI (from `cli/`):
 
-## What We're Looking For
+   ```bash
+   go build ./...
+   go test ./...
+   ```
 
-- **Bug reports** — especially around gate enforcement, quest lifecycle, and fellowship coordination
-- **Skill improvements** — clearer prompts, better phase transitions, edge case handling
-- **Hook hardening** — error handling, new test cases, edge case coverage
-- **Documentation** — README clarity, config examples, usage guides
+You need a recent Go toolchain (see the `go` directive in `cli/go.mod`).
+
+## How Hooks Work
+
+Hooks are subcommands of the CLI, not standalone scripts. `plugin/hooks/hooks.json` maps Claude Code hook events to `fellowship hook <name>` invocations; each handler lives in `cli/internal/hooks/` and is dispatched from `runHook` in `cli/cmd/fellowship/main.go`.
+
+- Input: the hook payload is JSON on stdin, parsed by `hooks.ParseInput`.
+- Output: **exit 0 allows** the tool call; **exit 2 blocks** it (the message on stderr is surfaced to Claude). Some hooks emit a JSON decision on stdout instead (e.g. gate-submit).
+- Posture: gate hooks fail *closed* (block on internal error) so enforcement can't be silently skipped. The `worktree-guard` backstop is the exception — it is defense-in-depth behind lead-provisioned isolation, so it fails *open* (allow) on any resolution failure and blocks only on a positive main-tree mis-placement detection.
+
+Current hooks: `gate-guard`, `gate-submit`, `gate-prereq`, `completion-guard`, `metadata-track`, `file-track`, `worktree-guard`. Run `fellowship` with no args for the full command reference.
 
 ## How to Contribute
 
 1. Open an issue first for non-trivial changes so we can discuss the approach
 2. Fork the repo and create a branch from `main`
 3. Make your changes
-4. Run `./hooks/test-hooks.sh` and confirm all tests pass
+4. For CLI changes, run the checks below and confirm they pass
 5. Open a PR with a clear description of what and why
 
 ## Conventions
 
 - **Commits**: use conventional commits (`feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`)
-- **Skills**: SKILL.md files with YAML frontmatter (`name` and `description` fields)
-- **Skill names**: must not collide with Claude Code built-in commands (`help`, `clear`, etc.)
-- **Hooks**: bash scripts in `hooks/scripts/`, sourcing `_common.sh` for shared state file logic
-- **Tests**: add test cases to `hooks/test-hooks.sh` for any hook behavior changes
-- **Changelog**: don't edit — maintainer updates it at release time
+- **Go**: idiomatic Go, standard library where practical, clear error handling. Keep hook decision logic pure and table-test it (see `cli/internal/hooks/*_test.go`).
+- **Skills**: `SKILL.md` files with YAML frontmatter (`name` and `description`). Commands use `description` only.
+- **Skill names**: must not collide with Claude Code built-in commands (`help`, `clear`, `config`, etc.)
+- **Changelog**: the README `## Changelog` is append-only per version and updated by the maintainer at release time. Don't edit historical entries.
 
 ## Repo Structure
 
 ```
-.claude-plugin/plugin.json   # Plugin manifest
-skills/<name>/SKILL.md       # Skills (markdown with YAML frontmatter)
-agents/<name>.md             # Agent definitions
-hooks/hooks.json             # Plugin hook definitions
-hooks/scripts/*.sh           # Gate enforcement scripts (require jq)
-hooks/test-hooks.sh          # Hook test suite
-README.md                    # User-facing docs
-CLAUDE.md                    # AI assistant conventions
+.claude-plugin/plugin.json          # Plugin manifest (repo root; points to plugin/ paths)
+plugin/skills/<name>/SKILL.md       # Skills — auto-invocable by Claude
+plugin/commands/<name>.md           # Commands — user-invoked only
+plugin/agents/<name>.md             # Agent definitions
+plugin/hooks/hooks.json             # Maps hook events to `fellowship hook <name>`
+plugin/hooks/scripts/ensure-binary.sh  # Downloads the CLI binary from GitHub releases
+plugin/hooks/scripts/fellowship.sh  # Thin wrapper — ensures binary, then exec's it
+cli/cmd/fellowship/main.go          # CLI entrypoint and subcommand dispatch
+cli/internal/hooks/                 # Hook decision logic (pure, table-tested)
+cli/internal/                       # State, db (SQLite), dashboard, herald, etc.
+README.md                           # User-facing docs and changelog
+CLAUDE.md                           # AI assistant conventions
 ```
 
 ## Testing
 
-The hook test suite is the primary automated test:
+For CLI changes, run from `cli/`:
 
 ```bash
-./hooks/test-hooks.sh
+gofmt -l .        # formatting — must report no files
+go vet ./...      # static checks
+go test ./...     # unit tests
 ```
 
-For end-to-end testing, run a fellowship or quest locally with `claude --plugin-dir .` and verify gate behavior manually.
+For plugin (prompt-layer) changes, run a fellowship or quest locally with `claude --plugin-dir .` and verify behavior manually.
 
 ## Questions?
 

--- a/cli/cmd/fellowship/main.go
+++ b/cli/cmd/fellowship/main.go
@@ -282,7 +282,13 @@ func runHook(d *db.DB, name string) int {
 			if err != nil {
 				input = &hooks.HookInput{}
 			}
-			if result := hooks.WorktreeGuard(input); result.Block {
+			// Only enumerate worktrees when the command looks like a cd/pushd,
+			// so the extra git call is off the common hot path.
+			var worktrees []string
+			if c := strings.TrimSpace(input.ToolInput.Command); strings.HasPrefix(c, "cd ") || strings.HasPrefix(c, "pushd ") {
+				worktrees = listQuestWorktrees(cwd)
+			}
+			if result := hooks.WorktreeGuard(input, hooks.CanonicalPath(cwd), worktrees); result.Block {
 				fmt.Fprintln(os.Stderr, result.Message)
 				return 2
 			}
@@ -516,10 +522,10 @@ func runWorktreeGuard(ctx context.Context, d *db.DB, cwd string) int {
 	// returns a resolved path; the cwd-derived main root does not.
 	result := hooks.IsolationGuard(hooks.IsolationParams{
 		FellowshipActive: active,
-		MainRoot:         canonicalPath(mainRoot),
-		SessionTopLevel:  canonicalPath(gitRootFrom(cwd)),
+		MainRoot:         hooks.CanonicalPath(mainRoot),
+		SessionTopLevel:  hooks.CanonicalPath(gitRootFrom(cwd)),
 		ToolName:         input.ToolName,
-		FilePath:         canonicalPath(filePath),
+		FilePath:         hooks.CanonicalPath(filePath),
 		DataDirName:      datadir.Name(),
 	})
 	if result.Block {
@@ -551,33 +557,6 @@ func fellowshipRunning(fs *dashboard.FellowshipState) bool {
 		}
 	}
 	return false
-}
-
-// canonicalPath resolves symlinks in p, falling back gracefully for paths that
-// don't exist yet (e.g. a Write target): it resolves the longest existing
-// ancestor and re-appends the missing remainder. Returns a cleaned absolute
-// path. An empty input returns empty.
-func canonicalPath(p string) string {
-	if p == "" {
-		return ""
-	}
-	p = filepath.Clean(p)
-	rem := ""
-	cur := p
-	for {
-		if resolved, err := filepath.EvalSymlinks(cur); err == nil {
-			if rem == "" {
-				return resolved
-			}
-			return filepath.Join(resolved, rem)
-		}
-		parent := filepath.Dir(cur)
-		if parent == cur {
-			return p // reached the root without resolving; use as-is
-		}
-		rem = filepath.Join(filepath.Base(cur), rem)
-		cur = parent
-	}
 }
 
 func runGate(d *db.DB, args []string) int {
@@ -2064,6 +2043,35 @@ func gitRootOrCwd() string {
 		return cwd
 	}
 	return strings.TrimSpace(string(out))
+}
+
+// listQuestWorktrees returns the canonicalized roots of all git worktrees for
+// the repo containing dir, excluding the main worktree. Used by the lead's
+// cd-guard to recognize quest worktrees created OUTSIDE the main tree (not just
+// the legacy .claude/worktrees location). Returns nil if git is unavailable.
+func listQuestWorktrees(dir string) []string {
+	cmd := exec.Command("git", "worktree", "list", "--porcelain")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		return nil
+	}
+	mainRoot := ""
+	if mr, err := resolveMainRepoFromCwd(dir); err == nil {
+		mainRoot = hooks.CanonicalPath(mr)
+	}
+	var paths []string
+	for _, line := range strings.Split(string(out), "\n") {
+		if !strings.HasPrefix(line, "worktree ") {
+			continue
+		}
+		p := hooks.CanonicalPath(strings.TrimSpace(strings.TrimPrefix(line, "worktree ")))
+		if p == "" || p == mainRoot {
+			continue
+		}
+		paths = append(paths, p)
+	}
+	return paths
 }
 
 // gitRootFrom returns the git root for a given directory.

--- a/cli/cmd/fellowship/main.go
+++ b/cli/cmd/fellowship/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/justinjdev/fellowship/cli/internal/errand"
 	"github.com/justinjdev/fellowship/cli/internal/herald"
 	"github.com/justinjdev/fellowship/cli/internal/hooks"
+	"github.com/justinjdev/fellowship/cli/internal/install"
 	"github.com/justinjdev/fellowship/cli/internal/state"
 	"github.com/justinjdev/fellowship/cli/internal/status"
 	"github.com/justinjdev/fellowship/cli/internal/tome"
@@ -169,6 +170,7 @@ Fellowship state:
   state init              Initialize fellowship in DB
     --name NAME           Fellowship name (required)
     --base-branch BRANCH  Base branch for quest worktrees (default: auto-detected)
+    --skip-hook-install   Skip registering/committing the worktree-guard hook
   state add-quest         Add a quest entry to fellowship state
     --name NAME           Quest name (required)
     --task "DESC"         Task description (required)
@@ -1558,10 +1560,11 @@ func runStateInit(d *db.DB, args []string) int {
 	fs := flag.NewFlagSet("state init", flag.ExitOnError)
 	name := fs.String("name", "", "Fellowship name (required)")
 	baseBranch := fs.String("base-branch", "", "Base branch for quest worktrees (Gandalf detects automatically; use this to override)")
+	skipHookInstall := fs.Bool("skip-hook-install", false, "Do not register/commit the worktree-guard hook in .claude/settings.json")
 	fs.Parse(args)
 
 	if *name == "" {
-		fmt.Fprintln(os.Stderr, "usage: fellowship state init --name <name> [--base-branch BRANCH]")
+		fmt.Fprintln(os.Stderr, "usage: fellowship state init --name <name> [--base-branch BRANCH] [--skip-hook-install]")
 		return 1
 	}
 
@@ -1583,7 +1586,34 @@ func runStateInit(d *db.DB, args []string) int {
 		return 1
 	}
 	fmt.Printf("Fellowship %q initialized\n", *name)
+
+	// Register the worktree-guard hook in the project's .claude/settings.local.json.
+	// Teammate sessions do NOT inherit plugin hooks, so this settings file is
+	// what makes a session enforce isolation. settings.local.json is git-ignored,
+	// so this touches no git history and leaves no untracked file — the lead
+	// copies it into each worktree at spawn (see the fellowship skill).
+	// Best-effort — a hook-install hiccup must not fail init.
+	if !*skipHookInstall {
+		installWorktreeGuardHook(root)
+	}
 	return 0
+}
+
+// installWorktreeGuardHook merges the worktree-guard hook into the project's
+// git-ignored .claude/settings.local.json (idempotent, preserving existing
+// settings). The lead copies that file into each worktree at spawn. Any failure
+// is a warning, never fatal — the hook is defense-in-depth behind
+// lead-provisioned isolation and the teammate self-check.
+func installWorktreeGuardHook(root string) {
+	changed, err := install.EnsureWorktreeGuardHook(root)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "fellowship: warning: could not register worktree-guard hook: %v\n", err)
+		return
+	}
+	if changed {
+		fmt.Println("Registered worktree-guard hook in .claude/settings.local.json.")
+	}
+	fmt.Println("Copy .claude/settings.local.json into each quest worktree at spawn so teammates inherit the guard.")
 }
 
 func runStateAddQuest(d *db.DB, args []string) int {
@@ -1746,9 +1776,9 @@ func runStateCleanWorktrees(d *db.DB, args []string) int {
 	fs.Parse(args)
 
 	type cleanResult struct {
-		name        string
-		wasPending  bool
-		wasHeld     bool
+		name       string
+		wasPending bool
+		wasHeld    bool
 	}
 
 	var cleaned []cleanResult

--- a/cli/cmd/fellowship/main.go
+++ b/cli/cmd/fellowship/main.go
@@ -135,6 +135,7 @@ Hook commands (called by Claude Code hooks, read stdin):
   hook metadata-track    Track phase metadata updates
   hook completion-guard  Block task completion unless phase is Complete
   hook file-track        Record file touches in quest tome
+  hook worktree-guard    Block source writes to the main tree during a fellowship
 
 Agent/lead commands:
   gate status            Show current phase, prereqs, pending/held state
@@ -249,6 +250,13 @@ func runHook(d *db.DB, name string) int {
 	ctx := context.Background()
 	cwd, _ := os.Getwd()
 	gitRoot := gitRootFrom(cwd)
+
+	// Worktree isolation guard: self-contained, independent of quest state.
+	// Runs in teammate sessions (inherited via project settings), so it must
+	// not depend on quest lookup keyed to this worktree.
+	if name == "worktree-guard" {
+		return runWorktreeGuard(ctx, d, cwd)
+	}
 
 	// Find quest name for this worktree.
 	var questName string
@@ -463,6 +471,83 @@ func runHook(d *db.DB, name string) int {
 	default:
 		fmt.Fprintf(os.Stderr, "fellowship: unknown hook %q\n", name)
 		return 2
+	}
+}
+
+// runWorktreeGuard is the fail-closed backstop that keeps quest teammates from
+// writing source into the MAIN working tree during an active fellowship. It is
+// defense-in-depth behind lead-created `isolation: "worktree"`, so any internal
+// resolution failure allows the action (exit 0) rather than hard-blocking
+// unrelated work. Only a positive mis-placement detection blocks (exit 2).
+func runWorktreeGuard(ctx context.Context, d *db.DB, cwd string) int {
+	input, err := hooks.ParseInput(os.Stdin)
+	if err != nil {
+		return 0 // malformed input — allow (defense-in-depth, not primary gate)
+	}
+
+	mainRoot, err := resolveMainRepoFromCwd(cwd)
+	if err != nil {
+		return 0
+	}
+
+	// Inert unless a fellowship is initialized in the main repo's store.
+	active := false
+	d.WithConn(ctx, func(conn *db.Conn) error {
+		if _, err := dashboard.LoadFellowship(conn); err == nil {
+			active = true
+		}
+		return nil
+	})
+
+	filePath := input.ToolInput.FilePath
+	if filePath == "" {
+		filePath = input.ToolInput.NotebookPath
+	}
+	if filePath != "" && !filepath.IsAbs(filePath) {
+		filePath = filepath.Join(cwd, filePath)
+	}
+
+	// Canonicalize all paths so symlinked repo roots (e.g. macOS /tmp ->
+	// /private/tmp) don't defeat the main-root comparison. `git --show-toplevel`
+	// returns a resolved path; the cwd-derived main root does not.
+	result := hooks.IsolationGuard(hooks.IsolationParams{
+		FellowshipActive: active,
+		MainRoot:         canonicalPath(mainRoot),
+		SessionTopLevel:  canonicalPath(gitRootFrom(cwd)),
+		ToolName:         input.ToolName,
+		FilePath:         canonicalPath(filePath),
+	})
+	if result.Block {
+		fmt.Fprintln(os.Stderr, result.Message)
+		return 2
+	}
+	return 0
+}
+
+// canonicalPath resolves symlinks in p, falling back gracefully for paths that
+// don't exist yet (e.g. a Write target): it resolves the longest existing
+// ancestor and re-appends the missing remainder. Returns a cleaned absolute
+// path. An empty input returns empty.
+func canonicalPath(p string) string {
+	if p == "" {
+		return ""
+	}
+	p = filepath.Clean(p)
+	rem := ""
+	cur := p
+	for {
+		if resolved, err := filepath.EvalSymlinks(cur); err == nil {
+			if rem == "" {
+				return resolved
+			}
+			return filepath.Join(resolved, rem)
+		}
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			return p // reached the root without resolving; use as-is
+		}
+		rem = filepath.Join(filepath.Base(cur), rem)
+		cur = parent
 	}
 }
 

--- a/cli/cmd/fellowship/main.go
+++ b/cli/cmd/fellowship/main.go
@@ -170,7 +170,7 @@ Fellowship state:
   state init              Initialize fellowship in DB
     --name NAME           Fellowship name (required)
     --base-branch BRANCH  Base branch for quest worktrees (default: auto-detected)
-    --skip-hook-install   Skip registering/committing the worktree-guard hook
+    --skip-hook-install   Skip registering the worktree-guard hook in settings.local.json
   state add-quest         Add a quest entry to fellowship state
     --name NAME           Quest name (required)
     --task "DESC"         Task description (required)
@@ -492,12 +492,14 @@ func runWorktreeGuard(ctx context.Context, d *db.DB, cwd string) int {
 		return 0
 	}
 
-	// Inert unless a fellowship is initialized in the main repo's store.
+	// Inert unless a fellowship is actually running in the main repo's store.
 	active := false
 	d.WithConn(ctx, func(conn *db.Conn) error {
-		if _, err := dashboard.LoadFellowship(conn); err == nil {
-			active = true
+		fs, err := dashboard.LoadFellowship(conn)
+		if err != nil {
+			return nil
 		}
+		active = fellowshipRunning(fs)
 		return nil
 	})
 
@@ -518,12 +520,37 @@ func runWorktreeGuard(ctx context.Context, d *db.DB, cwd string) int {
 		SessionTopLevel:  canonicalPath(gitRootFrom(cwd)),
 		ToolName:         input.ToolName,
 		FilePath:         canonicalPath(filePath),
+		DataDirName:      datadir.Name(),
 	})
 	if result.Block {
 		fmt.Fprintln(os.Stderr, result.Message)
 		return 2
 	}
 	return 0
+}
+
+// fellowshipRunning reports whether a fellowship is actually in progress, as
+// opposed to merely initialized once. The fellowship DB row is never deleted,
+// so "a row exists" is a sticky signal that would block ordinary main-tree
+// edits forever after a single `state init`. Quest worktrees, by contrast, are
+// created when teammates spawn and removed when their work merges — so a live
+// quest worktree on disk is the signal that teammates may currently be running
+// and the guard should be armed. A finished (or never-started) fellowship whose
+// row lingers has no live worktree and reads as inert.
+func fellowshipRunning(fs *dashboard.FellowshipState) bool {
+	for _, q := range fs.Quests {
+		switch dashboard.QuestEntryStatus(q) {
+		case "completed", "cancelled":
+			continue
+		}
+		if q.Worktree == "" {
+			continue
+		}
+		if info, err := os.Stat(q.Worktree); err == nil && info.IsDir() {
+			return true
+		}
+	}
+	return false
 }
 
 // canonicalPath resolves symlinks in p, falling back gracefully for paths that
@@ -1560,7 +1587,7 @@ func runStateInit(d *db.DB, args []string) int {
 	fs := flag.NewFlagSet("state init", flag.ExitOnError)
 	name := fs.String("name", "", "Fellowship name (required)")
 	baseBranch := fs.String("base-branch", "", "Base branch for quest worktrees (Gandalf detects automatically; use this to override)")
-	skipHookInstall := fs.Bool("skip-hook-install", false, "Do not register/commit the worktree-guard hook in .claude/settings.json")
+	skipHookInstall := fs.Bool("skip-hook-install", false, "Do not register the worktree-guard hook in .claude/settings.local.json")
 	fs.Parse(args)
 
 	if *name == "" {

--- a/cli/internal/bulletin/bulletin.go
+++ b/cli/internal/bulletin/bulletin.go
@@ -55,8 +55,8 @@ func Post(conn *db.Conn, entry Entry) error {
 func Load(conn *db.Conn) ([]Entry, error) {
 	// First load all entries.
 	type row struct {
-		id        int64
-		entry     Entry
+		id    int64
+		entry Entry
 	}
 	var rows []row
 

--- a/cli/internal/db/migrate.go
+++ b/cli/internal/db/migrate.go
@@ -21,14 +21,14 @@ var execCommand = exec.Command
 // JSON structs for parsing legacy files.
 
 type fellowshipStateJSON struct {
-	Version    int                  `json:"version"`
-	Name       string               `json:"name"`
-	MainRepo   string               `json:"main_repo"`
-	BaseBranch string               `json:"base_branch"`
+	Version    int                   `json:"version"`
+	Name       string                `json:"name"`
+	MainRepo   string                `json:"main_repo"`
+	BaseBranch string                `json:"base_branch"`
 	Quests     []fellowshipQuestJSON `json:"quests"`
 	Scouts     []fellowshipScoutJSON `json:"scouts"`
 	Companies  []companyJSON         `json:"companies"`
-	CreatedAt  string               `json:"created_at"`
+	CreatedAt  string                `json:"created_at"`
 }
 
 type fellowshipQuestJSON struct {
@@ -52,29 +52,29 @@ type companyJSON struct {
 }
 
 type questStateJSON struct {
-	Version         int      `json:"version"`
-	QuestName       string   `json:"quest_name"`
-	TaskID          string   `json:"task_id"`
-	TeamName        string   `json:"team_name"`
-	Phase           string   `json:"phase"`
-	GatePending     bool     `json:"gate_pending"`
-	GateID          *string  `json:"gate_id"`
-	LembasCompleted bool     `json:"lembas_completed"`
-	MetadataUpdated bool     `json:"metadata_updated"`
-	Held            bool     `json:"held"`
-	HeldReason      *string  `json:"held_reason"`
+	Version          int      `json:"version"`
+	QuestName        string   `json:"quest_name"`
+	TaskID           string   `json:"task_id"`
+	TeamName         string   `json:"team_name"`
+	Phase            string   `json:"phase"`
+	GatePending      bool     `json:"gate_pending"`
+	GateID           *string  `json:"gate_id"`
+	LembasCompleted  bool     `json:"lembas_completed"`
+	MetadataUpdated  bool     `json:"metadata_updated"`
+	Held             bool     `json:"held"`
+	HeldReason       *string  `json:"held_reason"`
 	AutoApproveGates []string `json:"auto_approve_gates"`
 }
 
 type questTomeJSON struct {
-	Version         int              `json:"version"`
-	QuestName       string           `json:"quest_name"`
-	Task            string           `json:"task"`
-	PhasesCompleted []phaseRecJSON   `json:"phases_completed"`
-	GateHistory     []gateEventJSON  `json:"gate_history"`
-	FilesTouched    []string         `json:"files_touched"`
-	Respawns        int              `json:"respawns"`
-	Status          string           `json:"status"`
+	Version         int             `json:"version"`
+	QuestName       string          `json:"quest_name"`
+	Task            string          `json:"task"`
+	PhasesCompleted []phaseRecJSON  `json:"phases_completed"`
+	GateHistory     []gateEventJSON `json:"gate_history"`
+	FilesTouched    []string        `json:"files_touched"`
+	Respawns        int             `json:"respawns"`
+	Status          string          `json:"status"`
 }
 
 type phaseRecJSON struct {

--- a/cli/internal/hooks/guard.go
+++ b/cli/internal/hooks/guard.go
@@ -132,17 +132,16 @@ func isFellowshipEscapeCommand(command string) bool {
 	}
 	// Allowlist of subcommands safe to run during gate_pending.
 	allowed := map[string]bool{
-		"gate":    true, // approve/reject gates
-		"init":    true, // reset state file
+		"gate":     true, // approve/reject gates
+		"init":     true, // reset state file
 		"autopsy":  true, // write/read failure records
 		"bulletin": true, // read/write shared discovery board
 		"errand":   true, // read/update errand status
-		"status":  true, // read-only status scan
-		"eagles":  true, // read-only health scan
-		"tome":    true, // read-only quest history
-		"herald":  true, // read-only event log
-		"version": true, // print version
+		"status":   true, // read-only status scan
+		"eagles":   true, // read-only health scan
+		"tome":     true, // read-only quest history
+		"herald":   true, // read-only event log
+		"version":  true, // print version
 	}
 	return allowed[fields[1]]
 }
-

--- a/cli/internal/hooks/guard.go
+++ b/cli/internal/hooks/guard.go
@@ -50,11 +50,20 @@ func GateGuard(s *state.State, input *HookInput) HookResult {
 	return HookResult{}
 }
 
-// WorktreeGuard blocks the lead session from cd'ing into quest worktrees.
-// It is called when no quest state file exists (indicating this is the lead session).
-// Scoped commands (cd path && ...) are allowed since CWD doesn't persist between
-// Bash tool calls.
-func WorktreeGuard(input *HookInput) HookResult {
+// WorktreeGuard blocks the lead session from cd'ing into a quest worktree.
+// It is called when no quest state exists for the cwd (indicating the lead
+// session). A bare "cd <worktree>"/"pushd <worktree>" would move the lead onto
+// quest state and subject it to that quest's gate/hold blocks; scoped commands
+// ("cd <path> && <cmd>") are allowed since CWD doesn't persist between Bash
+// tool calls.
+//
+// worktreePaths is the set of live git worktree roots (absolute, main root
+// excluded) that the caller enumerates; a cd target equal to or under any of
+// them is blocked. This covers lead-provisioned worktrees created OUTSIDE the
+// main tree. The legacy ".claude/worktrees" location is always recognized even
+// when worktreePaths is empty. cwd resolves relative cd targets; pass "" to
+// match on the raw target only.
+func WorktreeGuard(input *HookInput, cwd string, worktreePaths []string) HookResult {
 	if input == nil {
 		return HookResult{}
 	}
@@ -62,8 +71,11 @@ func WorktreeGuard(input *HookInput) HookResult {
 	if cmd == "" {
 		return HookResult{}
 	}
-
-	if isWorktreeCD(cmd) {
+	target, ok := bareCDTarget(cmd)
+	if !ok {
+		return HookResult{}
+	}
+	if isWorktreeTarget(target, cwd, worktreePaths) {
 		return HookResult{
 			Block:   true,
 			Message: "Gandalf must not cd into quest worktrees. Use --dir <path> for fellowship commands, or absolute paths for reading files.",
@@ -72,35 +84,49 @@ func WorktreeGuard(input *HookInput) HookResult {
 	return HookResult{}
 }
 
-// isWorktreeCD detects bare "cd <worktree>" or "pushd <worktree>" commands.
-// Scoped commands like "cd <worktree> && <cmd>" are allowed.
-func isWorktreeCD(command string) bool {
+// bareCDTarget returns the target of an unscoped "cd"/"pushd" command. ok is
+// false for non-cd commands and for scoped commands like "cd path && cmd"
+// (safe — CWD does not persist between Bash tool calls).
+func bareCDTarget(command string) (string, bool) {
 	fields := strings.Fields(command)
-	if len(fields) < 2 {
-		return false
+	if len(fields) != 2 {
+		return "", false
 	}
-
-	verb := fields[0]
-	if verb != "cd" && verb != "pushd" {
-		return false
+	if fields[0] != "cd" && fields[0] != "pushd" {
+		return "", false
 	}
-
 	target := strings.Trim(fields[1], `"'`)
 	target = strings.TrimSuffix(target, ";")
-	if !isWorktreePath(target) {
-		return false
-	}
-
-	// If there's anything after the target, it's a scoped command — allow it.
-	// e.g., "cd path && git log" has fields[2] == "&&"
-	if len(fields) > 2 {
-		return false
-	}
-	return true
+	return target, true
 }
 
-// isWorktreePath checks if a path leads into or is the worktree directory.
-func isWorktreePath(path string) bool {
+// isWorktreeTarget reports whether a bare cd target points into a quest
+// worktree — either the legacy ".claude/worktrees" location, or (resolved
+// against cwd) a path equal to or under one of the supplied worktree roots.
+func isWorktreeTarget(target, cwd string, worktreePaths []string) bool {
+	if isLegacyWorktreePath(target) {
+		return true
+	}
+	if len(worktreePaths) == 0 {
+		return false
+	}
+	abs := target
+	if !filepath.IsAbs(abs) && cwd != "" {
+		abs = filepath.Join(cwd, abs)
+	}
+	abs = CanonicalPath(abs)
+	for _, wt := range worktreePaths {
+		wt = CanonicalPath(wt)
+		if abs == wt || strings.HasPrefix(abs, wt+string(filepath.Separator)) {
+			return true
+		}
+	}
+	return false
+}
+
+// isLegacyWorktreePath checks the historical ".claude/worktrees" location,
+// which predates lead-provisioned out-of-tree worktrees.
+func isLegacyWorktreePath(path string) bool {
 	normalized := strings.TrimSuffix(filepath.ToSlash(filepath.Clean(path)), "/")
 	return normalized == ".claude/worktrees" ||
 		strings.HasPrefix(normalized, ".claude/worktrees/") ||

--- a/cli/internal/hooks/guard_test.go
+++ b/cli/internal/hooks/guard_test.go
@@ -198,7 +198,7 @@ func TestWorktreeGuard_BlocksBareCD(t *testing.T) {
 		"cd .claude/worktrees/quest-1/src",
 	} {
 		input := &HookInput{ToolInput: ToolInput{Command: cmd}}
-		result := WorktreeGuard(input)
+		result := WorktreeGuard(input, "", nil)
 		if !result.Block {
 			t.Errorf("should block bare cd into worktree, cmd=%q", cmd)
 		}
@@ -207,7 +207,7 @@ func TestWorktreeGuard_BlocksBareCD(t *testing.T) {
 
 func TestWorktreeGuard_BlocksPushd(t *testing.T) {
 	input := &HookInput{ToolInput: ToolInput{Command: "pushd .claude/worktrees/quest-1"}}
-	result := WorktreeGuard(input)
+	result := WorktreeGuard(input, "", nil)
 	if !result.Block {
 		t.Error("should block pushd into worktree")
 	}
@@ -220,7 +220,7 @@ func TestWorktreeGuard_AllowsScopedCD(t *testing.T) {
 		"cd .claude/worktrees/quest-1 || echo fail",
 	} {
 		input := &HookInput{ToolInput: ToolInput{Command: cmd}}
-		result := WorktreeGuard(input)
+		result := WorktreeGuard(input, "", nil)
 		if result.Block {
 			t.Errorf("should allow scoped cd, cmd=%q", cmd)
 		}
@@ -234,7 +234,7 @@ func TestWorktreeGuard_AllowsNonWorktreeCD(t *testing.T) {
 		"cd ..",
 	} {
 		input := &HookInput{ToolInput: ToolInput{Command: cmd}}
-		result := WorktreeGuard(input)
+		result := WorktreeGuard(input, "", nil)
 		if result.Block {
 			t.Errorf("should allow cd to non-worktree path, cmd=%q", cmd)
 		}
@@ -248,7 +248,7 @@ func TestWorktreeGuard_AllowsNonCDCommands(t *testing.T) {
 		"grep -r foo .claude/worktrees/quest-1",
 	} {
 		input := &HookInput{ToolInput: ToolInput{Command: cmd}}
-		result := WorktreeGuard(input)
+		result := WorktreeGuard(input, "", nil)
 		if result.Block {
 			t.Errorf("should allow non-cd commands referencing worktrees, cmd=%q", cmd)
 		}
@@ -262,7 +262,7 @@ func TestWorktreeGuard_BlocksWorktreeRoot(t *testing.T) {
 		"pushd .claude/worktrees",
 	} {
 		input := &HookInput{ToolInput: ToolInput{Command: cmd}}
-		result := WorktreeGuard(input)
+		result := WorktreeGuard(input, "", nil)
 		if !result.Block {
 			t.Errorf("should block cd into worktree root, cmd=%q", cmd)
 		}
@@ -275,7 +275,7 @@ func TestWorktreeGuard_BlocksQuotedTarget(t *testing.T) {
 		`cd '.claude/worktrees/quest-1'`,
 	} {
 		input := &HookInput{ToolInput: ToolInput{Command: cmd}}
-		result := WorktreeGuard(input)
+		result := WorktreeGuard(input, "", nil)
 		if !result.Block {
 			t.Errorf("should block quoted cd into worktree, cmd=%q", cmd)
 		}
@@ -284,7 +284,7 @@ func TestWorktreeGuard_BlocksQuotedTarget(t *testing.T) {
 
 func TestWorktreeGuard_BlocksTrailingSemicolon(t *testing.T) {
 	input := &HookInput{ToolInput: ToolInput{Command: "cd .claude/worktrees/quest-1;"}}
-	result := WorktreeGuard(input)
+	result := WorktreeGuard(input, "", nil)
 	if !result.Block {
 		t.Errorf("should block cd with trailing semicolon")
 	}
@@ -292,15 +292,61 @@ func TestWorktreeGuard_BlocksTrailingSemicolon(t *testing.T) {
 
 func TestWorktreeGuard_AllowsEmptyCommand(t *testing.T) {
 	input := &HookInput{ToolInput: ToolInput{Command: ""}}
-	result := WorktreeGuard(input)
+	result := WorktreeGuard(input, "", nil)
 	if result.Block {
 		t.Error("should allow empty command")
 	}
 }
 
 func TestWorktreeGuard_AllowsNilInput(t *testing.T) {
-	result := WorktreeGuard(nil)
+	result := WorktreeGuard(nil, "", nil)
 	if result.Block {
 		t.Error("should allow nil input")
+	}
+}
+
+func TestWorktreeGuard_BlocksOutOfTreeWorktree(t *testing.T) {
+	worktrees := []string{"/repo/.worktrees/quest-1", "/repo-worktrees/quest-2"}
+	cases := []struct {
+		cmd string
+		cwd string
+	}{
+		{"cd /repo/.worktrees/quest-1", "/repo"},   // absolute
+		{"cd .worktrees/quest-1", "/repo"},         // relative to cwd
+		{"cd .worktrees/quest-1/src", "/repo"},     // subdir of a worktree
+		{"cd ../repo-worktrees/quest-2", "/repo"},  // sibling dir, relative
+		{"pushd /repo-worktrees/quest-2", "/repo"}, // absolute pushd
+	}
+	for _, c := range cases {
+		input := &HookInput{ToolInput: ToolInput{Command: c.cmd}}
+		result := WorktreeGuard(input, c.cwd, worktrees)
+		if !result.Block {
+			t.Errorf("should block cd into out-of-tree worktree, cmd=%q", c.cmd)
+		}
+	}
+}
+
+func TestWorktreeGuard_AllowsNonWorktreeCDWithWorktrees(t *testing.T) {
+	worktrees := []string{"/repo/.worktrees/quest-1"}
+	for _, cmd := range []string{
+		"cd /repo/src",                 // sibling of, not inside, a worktree
+		"cd src/auth",                  // ordinary relative dir
+		"cd /repo/.worktrees-backup/x", // prefix-adjacent but not a real child
+	} {
+		input := &HookInput{ToolInput: ToolInput{Command: cmd}}
+		result := WorktreeGuard(input, "/repo", worktrees)
+		if result.Block {
+			t.Errorf("should allow cd to non-worktree path, cmd=%q", cmd)
+		}
+	}
+}
+
+func TestWorktreeGuard_AllowsScopedOutOfTreeCD(t *testing.T) {
+	// Scoped commands remain safe — CWD doesn't persist between Bash calls.
+	worktrees := []string{"/repo/.worktrees/quest-1"}
+	input := &HookInput{ToolInput: ToolInput{Command: "cd /repo/.worktrees/quest-1 && go test ./..."}}
+	result := WorktreeGuard(input, "/repo", worktrees)
+	if result.Block {
+		t.Error("scoped cd into an out-of-tree worktree should be allowed")
 	}
 }

--- a/cli/internal/hooks/guard_test.go
+++ b/cli/internal/hooks/guard_test.go
@@ -170,9 +170,9 @@ func TestGateGuard_BlocksChainedCommandsWithFellowshipEscape(t *testing.T) {
 		"fellowship gate reject; rm -rf /",
 		"fellowship gate reject || evil",
 		"echo foo | fellowship gate reject",
-		"echo fellowship gate reject",    // first token is echo, not fellowship
+		"echo fellowship gate reject",      // first token is echo, not fellowship
 		"fellowship gate reject\nrm -rf /", // newline-separated second command
-		"$(fellowship gate reject)",      // subshell
+		"$(fellowship gate reject)",        // subshell
 	} {
 		input := &HookInput{ToolInput: ToolInput{Command: cmd}}
 		result := GateGuard(s, input)

--- a/cli/internal/hooks/input.go
+++ b/cli/internal/hooks/input.go
@@ -7,6 +7,7 @@ import (
 )
 
 type HookInput struct {
+	ToolName  string    `json:"tool_name,omitempty"`
 	ToolInput ToolInput `json:"tool_input"`
 }
 

--- a/cli/internal/hooks/isolation.go
+++ b/cli/internal/hooks/isolation.go
@@ -1,0 +1,114 @@
+package hooks
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// IsolationParams carries the facts the isolation guard needs, already resolved
+// by the caller (git top-levels, fellowship-active flag, absolute file path).
+// Keeping the decision pure makes it testable without spawning git or opening a DB.
+type IsolationParams struct {
+	// FellowshipActive is true when a fellowship is initialized in the main repo.
+	FellowshipActive bool
+	// MainRoot is the absolute path to the main worktree root (parent of the
+	// shared git common dir).
+	MainRoot string
+	// SessionTopLevel is the absolute path to the current session's git top-level
+	// (`git rev-parse --show-toplevel`).
+	SessionTopLevel string
+	// ToolName is the PreToolUse tool name (Edit, Write, NotebookEdit, ...).
+	ToolName string
+	// FilePath is the absolute, cleaned path to the tool's target file.
+	FilePath string
+}
+
+// coordinationDirs are top-level directories in the main worktree that hold
+// fellowship coordination state or git metadata. Writes here are always allowed
+// even in the main tree — Gandalf legitimately manages them.
+var coordinationDirs = []string{".fellowship", ".git", ".claude"}
+
+// IsolationGuard is the fail-closed backstop for worktree isolation. During an
+// active fellowship, a quest teammate must operate inside its own git worktree.
+// If a session whose top-level IS the main worktree root tries to Edit/Write a
+// source file there, the teammate was mis-placed (isolation was skipped) and the
+// write is blocked. Teammates in their own worktree, and non-mutating tools, are
+// never blocked. This is defense-in-depth: lead-created `isolation: "worktree"`
+// is the primary guarantee.
+func IsolationGuard(p IsolationParams) HookResult {
+	// Inert unless a fellowship is active — installing the guard is always safe.
+	if !p.FellowshipActive {
+		return HookResult{}
+	}
+	// Only source-mutating tools are guarded; Bash/git are left to Gandalf.
+	if !isSourceMutatingTool(p.ToolName) {
+		return HookResult{}
+	}
+	// The whole point: a session correctly in its own worktree is never blocked.
+	if !samePath(p.SessionTopLevel, p.MainRoot) {
+		return HookResult{}
+	}
+	if p.FilePath == "" {
+		return HookResult{}
+	}
+	rel, ok := relWithin(p.MainRoot, p.FilePath)
+	if !ok {
+		// Target lives outside the main worktree — not our concern.
+		return HookResult{}
+	}
+	if isCoordinationPath(rel) {
+		return HookResult{}
+	}
+	return HookResult{
+		Block: true,
+		Message: fmt.Sprintf(
+			"worktree-guard: refusing to write '%s' in the MAIN working tree during an active fellowship; quest work belongs in your isolated worktree",
+			filepath.ToSlash(rel),
+		),
+	}
+}
+
+// isSourceMutatingTool reports whether the tool writes files we protect.
+func isSourceMutatingTool(name string) bool {
+	switch name {
+	case "Edit", "Write", "NotebookEdit":
+		return true
+	default:
+		return false
+	}
+}
+
+// samePath compares two paths for equality after cleaning.
+func samePath(a, b string) bool {
+	if a == "" || b == "" {
+		return false
+	}
+	return filepath.Clean(a) == filepath.Clean(b)
+}
+
+// relWithin returns the path of target relative to root and whether target is
+// inside root. A target equal to or outside root returns ok=false.
+func relWithin(root, target string) (string, bool) {
+	rel, err := filepath.Rel(filepath.Clean(root), filepath.Clean(target))
+	if err != nil {
+		return "", false
+	}
+	rel = filepath.ToSlash(rel)
+	if rel == "." || rel == ".." || strings.HasPrefix(rel, "../") {
+		return "", false
+	}
+	return rel, true
+}
+
+// isCoordinationPath reports whether a root-relative path lives under a
+// coordination or git-metadata directory that is exempt from the guard.
+func isCoordinationPath(rel string) bool {
+	first := strings.SplitN(filepath.ToSlash(rel), "/", 2)[0]
+	for _, dir := range coordinationDirs {
+		if first == dir {
+			return true
+		}
+	}
+	return false
+}

--- a/cli/internal/hooks/isolation.go
+++ b/cli/internal/hooks/isolation.go
@@ -22,12 +22,11 @@ type IsolationParams struct {
 	ToolName string
 	// FilePath is the absolute, cleaned path to the tool's target file.
 	FilePath string
+	// DataDirName is the configured fellowship data directory name
+	// (datadir.Name(), e.g. ".fellowship" or a user override). Writes under it
+	// are coordination state, always allowed even in the main tree.
+	DataDirName string
 }
-
-// coordinationDirs are top-level directories in the main worktree that hold
-// fellowship coordination state or git metadata. Writes here are always allowed
-// even in the main tree — Gandalf legitimately manages them.
-var coordinationDirs = []string{".fellowship", ".git", ".claude"}
 
 // IsolationGuard is the fail-closed backstop for worktree isolation. During an
 // active fellowship, a quest teammate must operate inside its own git worktree.
@@ -57,7 +56,7 @@ func IsolationGuard(p IsolationParams) HookResult {
 		// Target lives outside the main worktree — not our concern.
 		return HookResult{}
 	}
-	if isCoordinationPath(rel) {
+	if isCoordinationPath(rel, p.DataDirName) {
 		return HookResult{}
 	}
 	return HookResult{
@@ -102,13 +101,14 @@ func relWithin(root, target string) (string, bool) {
 }
 
 // isCoordinationPath reports whether a root-relative path lives under a
-// coordination or git-metadata directory that is exempt from the guard.
-func isCoordinationPath(rel string) bool {
+// coordination or git-metadata directory that is exempt from the guard. Gandalf
+// legitimately manages these even in the main tree. The data directory is
+// user-configurable (datadir.Name), so the caller passes its resolved name
+// rather than assuming the ".fellowship" default; .git and .claude are fixed.
+func isCoordinationPath(rel, dataDirName string) bool {
 	first := strings.SplitN(filepath.ToSlash(rel), "/", 2)[0]
-	for _, dir := range coordinationDirs {
-		if first == dir {
-			return true
-		}
+	if first == ".git" || first == ".claude" {
+		return true
 	}
-	return false
+	return dataDirName != "" && first == dataDirName
 }

--- a/cli/internal/hooks/isolation_test.go
+++ b/cli/internal/hooks/isolation_test.go
@@ -50,10 +50,42 @@ func TestIsolationGuard_AllowsCoordinationDirWrite(t *testing.T) {
 			SessionTopLevel:  "/repo",
 			ToolName:         "Write",
 			FilePath:         path,
+			DataDirName:      ".fellowship",
 		})
 		if result.Block {
 			t.Errorf("coordination-dir write must be allowed: %s", path)
 		}
+	}
+}
+
+func TestIsolationGuard_AllowsCustomDataDirWrite(t *testing.T) {
+	// A user-configured dataDir must be exempt just like the default.
+	result := IsolationGuard(IsolationParams{
+		FellowshipActive: true,
+		MainRoot:         "/repo",
+		SessionTopLevel:  "/repo",
+		ToolName:         "Write",
+		FilePath:         "/repo/queststate/checkpoint.md",
+		DataDirName:      "queststate",
+	})
+	if result.Block {
+		t.Error("write under a custom dataDir must be allowed")
+	}
+}
+
+func TestIsolationGuard_BlocksDefaultDataDirNameWhenCustomConfigured(t *testing.T) {
+	// If the user renamed the data dir, ".fellowship" is now an ordinary source
+	// path in the main tree and must be blocked.
+	result := IsolationGuard(IsolationParams{
+		FellowshipActive: true,
+		MainRoot:         "/repo",
+		SessionTopLevel:  "/repo",
+		ToolName:         "Write",
+		FilePath:         "/repo/.fellowship/notes.md",
+		DataDirName:      "queststate",
+	})
+	if !result.Block {
+		t.Error("stale .fellowship path should not be exempt when dataDir is customized")
 	}
 }
 

--- a/cli/internal/hooks/isolation_test.go
+++ b/cli/internal/hooks/isolation_test.go
@@ -1,0 +1,162 @@
+package hooks
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestIsolationGuard_AllowsInWorktree(t *testing.T) {
+	// Session top-level is a worktree, distinct from the main root: never blocked.
+	result := IsolationGuard(IsolationParams{
+		FellowshipActive: true,
+		MainRoot:         "/repo",
+		SessionTopLevel:  "/repo/.worktrees/quest-1",
+		ToolName:         "Write",
+		FilePath:         "/repo/.worktrees/quest-1/src/main.go",
+	})
+	if result.Block {
+		t.Errorf("teammate in its own worktree must be allowed, got: %s", result.Message)
+	}
+}
+
+func TestIsolationGuard_BlocksMainTreeSourceWrite(t *testing.T) {
+	for _, tool := range []string{"Edit", "Write", "NotebookEdit"} {
+		result := IsolationGuard(IsolationParams{
+			FellowshipActive: true,
+			MainRoot:         "/repo",
+			SessionTopLevel:  "/repo",
+			ToolName:         tool,
+			FilePath:         "/repo/src/main.go",
+		})
+		if !result.Block {
+			t.Errorf("main-tree source write via %s during active fellowship must block", tool)
+		}
+		if !strings.Contains(result.Message, "src/main.go") {
+			t.Errorf("message should name the offending file, got: %s", result.Message)
+		}
+	}
+}
+
+func TestIsolationGuard_AllowsCoordinationDirWrite(t *testing.T) {
+	for _, path := range []string{
+		"/repo/.fellowship/checkpoint.md",
+		"/repo/.git/COMMIT_EDITMSG",
+		"/repo/.claude/settings.json",
+	} {
+		result := IsolationGuard(IsolationParams{
+			FellowshipActive: true,
+			MainRoot:         "/repo",
+			SessionTopLevel:  "/repo",
+			ToolName:         "Write",
+			FilePath:         path,
+		})
+		if result.Block {
+			t.Errorf("coordination-dir write must be allowed: %s", path)
+		}
+	}
+}
+
+func TestIsolationGuard_AllowsWhenNoFellowship(t *testing.T) {
+	result := IsolationGuard(IsolationParams{
+		FellowshipActive: false,
+		MainRoot:         "/repo",
+		SessionTopLevel:  "/repo",
+		ToolName:         "Write",
+		FilePath:         "/repo/src/main.go",
+	})
+	if result.Block {
+		t.Error("guard must be inert when no fellowship is active")
+	}
+}
+
+func TestIsolationGuard_AllowsNonMutatingTool(t *testing.T) {
+	for _, tool := range []string{"Bash", "Read", "Grep", "Glob", ""} {
+		result := IsolationGuard(IsolationParams{
+			FellowshipActive: true,
+			MainRoot:         "/repo",
+			SessionTopLevel:  "/repo",
+			ToolName:         tool,
+			FilePath:         "/repo/src/main.go",
+		})
+		if result.Block {
+			t.Errorf("non-mutating tool %q must be allowed", tool)
+		}
+	}
+}
+
+func TestIsolationGuard_AllowsNotebookPathInWorktree(t *testing.T) {
+	result := IsolationGuard(IsolationParams{
+		FellowshipActive: true,
+		MainRoot:         "/repo",
+		SessionTopLevel:  "/repo/.worktrees/quest-2",
+		ToolName:         "NotebookEdit",
+		FilePath:         "/repo/.worktrees/quest-2/analysis.ipynb",
+	})
+	if result.Block {
+		t.Error("NotebookEdit inside a worktree must be allowed")
+	}
+}
+
+func TestIsolationGuard_AllowsWriteOutsideMainRoot(t *testing.T) {
+	// Some other repo/path that is not under the main root.
+	result := IsolationGuard(IsolationParams{
+		FellowshipActive: true,
+		MainRoot:         "/repo",
+		SessionTopLevel:  "/repo",
+		ToolName:         "Write",
+		FilePath:         "/tmp/scratch.txt",
+	})
+	if result.Block {
+		t.Error("writes outside the main worktree are not the guard's concern")
+	}
+}
+
+func TestIsolationGuard_AllowsEmptyFilePath(t *testing.T) {
+	result := IsolationGuard(IsolationParams{
+		FellowshipActive: true,
+		MainRoot:         "/repo",
+		SessionTopLevel:  "/repo",
+		ToolName:         "Write",
+		FilePath:         "",
+	})
+	if result.Block {
+		t.Error("empty file path must be allowed")
+	}
+}
+
+func TestRelWithin(t *testing.T) {
+	cases := []struct {
+		root, target string
+		wantRel      string
+		wantOK       bool
+	}{
+		{"/repo", "/repo/src/main.go", "src/main.go", true},
+		{"/repo", "/repo", "", false},
+		{"/repo", "/other/file.go", "", false},
+		{"/repo", "/repository/file.go", "", false}, // prefix but not a child
+	}
+	for _, c := range cases {
+		rel, ok := relWithin(c.root, c.target)
+		if ok != c.wantOK || rel != c.wantRel {
+			t.Errorf("relWithin(%q,%q) = (%q,%v), want (%q,%v)",
+				c.root, c.target, rel, ok, c.wantRel, c.wantOK)
+		}
+	}
+}
+
+func TestSamePath(t *testing.T) {
+	if !samePath("/repo", "/repo/") {
+		t.Error("trailing slash should compare equal after clean")
+	}
+	if samePath("/repo", "/repo/sub") {
+		t.Error("distinct paths must not be equal")
+	}
+	if samePath("", "/repo") {
+		t.Error("empty path must not match")
+	}
+	// filepath.Clean is platform-aware; sanity check the join case.
+	if !samePath(filepath.Join("/repo", "a", ".."), "/repo") {
+		t.Error("normalized paths should compare equal")
+	}
+}

--- a/cli/internal/hooks/paths.go
+++ b/cli/internal/hooks/paths.go
@@ -1,0 +1,32 @@
+package hooks
+
+import "path/filepath"
+
+// CanonicalPath resolves symlinks in p, falling back gracefully for paths that
+// don't exist yet (e.g. a Write target or a not-yet-created cd target): it
+// resolves the longest existing ancestor and re-appends the missing remainder.
+// Returns a cleaned absolute path; an empty input returns empty. Both the
+// isolation guard and the cd-guard canonicalize their inputs through this so
+// symlinked repo roots (e.g. macOS /tmp -> /private/tmp) compare equal.
+func CanonicalPath(p string) string {
+	if p == "" {
+		return ""
+	}
+	p = filepath.Clean(p)
+	rem := ""
+	cur := p
+	for {
+		if resolved, err := filepath.EvalSymlinks(cur); err == nil {
+			if rem == "" {
+				return resolved
+			}
+			return filepath.Join(resolved, rem)
+		}
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			return p // reached the root without resolving; use as-is
+		}
+		rem = filepath.Join(filepath.Base(cur), rem)
+		cur = parent
+	}
+}

--- a/cli/internal/install/install.go
+++ b/cli/internal/install/install.go
@@ -1,3 +1,9 @@
+// Package install registers fellowship's project-level hooks into a repo's
+// .claude/settings.local.json. Teammate sessions spawned via the Agent tool do
+// NOT inherit plugin hooks, so the worktree-guard must live in a project
+// settings file the teammate's session reads. settings.local.json is used
+// because it is git-ignored: it never touches git history and never shows up as
+// an untracked file. The lead copies it into each worktree at spawn.
 package install
 
 import (
@@ -7,89 +13,123 @@ import (
 	"path/filepath"
 )
 
-type hookEntry struct {
-	Type    string `json:"type"`
-	Command string `json:"command"`
-}
+// These mirror the worktree-guard PreToolUse hook in plugin/hooks/hooks.json.
+// Keep them in sync with that file.
+const (
+	worktreeGuardMatcher = "Edit|Write|NotebookEdit"
+	worktreeGuardCommand = "${HOME}/.claude/fellowship/bin/fellowship hook worktree-guard"
+	worktreeGuardTimeout = 5
+)
 
-type hookMatcher struct {
-	Matcher string      `json:"matcher"`
-	Hooks   []hookEntry `json:"hooks"`
-}
-
-func buildHooks(binPath string) map[string][]hookMatcher {
-	return map[string][]hookMatcher{
-		"PreToolUse": {
-			{Matcher: "Edit|Write|Bash|Agent|Skill|NotebookEdit", Hooks: []hookEntry{{Type: "command", Command: binPath + " hook gate-guard"}}},
-			{Matcher: "SendMessage", Hooks: []hookEntry{{Type: "command", Command: binPath + " hook gate-submit"}}},
-			{Matcher: "TaskUpdate", Hooks: []hookEntry{{Type: "command", Command: binPath + " hook completion-guard"}}},
-		},
-		"PostToolUse": {
-			{Matcher: "Skill", Hooks: []hookEntry{{Type: "command", Command: binPath + " hook gate-prereq"}}},
-			{Matcher: "TaskUpdate", Hooks: []hookEntry{{Type: "command", Command: binPath + " hook metadata-track"}}},
-		},
-	}
-}
-
-func Install(projectDir, binPath string) error {
+// EnsureWorktreeGuardHook merges the worktree-guard PreToolUse hook into the
+// project's .claude/settings.local.json, preserving every other setting and
+// hook. It is idempotent: if the hook command is already registered it returns
+// (false, nil) without touching the file, and returns (true, nil) when it
+// writes a change. A settings file whose "hooks"/"PreToolUse" values have an
+// unexpected shape is reported as an error and left untouched rather than
+// clobbered.
+func EnsureWorktreeGuardHook(projectDir string) (bool, error) {
 	claudeDir := filepath.Join(projectDir, ".claude")
-	settingsPath := filepath.Join(claudeDir, "settings.json")
+	settingsPath := filepath.Join(claudeDir, "settings.local.json")
 
-	if err := os.MkdirAll(claudeDir, 0755); err != nil {
-		return fmt.Errorf("creating .claude dir: %w", err)
-	}
-
-	settings := make(map[string]any)
+	settings := map[string]any{}
 	if data, err := os.ReadFile(settingsPath); err == nil {
-		if err := json.Unmarshal(data, &settings); err != nil {
-			return fmt.Errorf("parsing existing settings.json: %w", err)
+		if len(data) > 0 {
+			if err := json.Unmarshal(data, &settings); err != nil {
+				return false, fmt.Errorf("parsing %s: %w", settingsPath, err)
+			}
 		}
+	} else if !os.IsNotExist(err) {
+		return false, fmt.Errorf("reading %s: %w", settingsPath, err)
 	}
 
-	settings["hooks"] = buildHooks(binPath)
+	hooks, preToolUse, err := hooksAndPreToolUse(settings)
+	if err != nil {
+		return false, err
+	}
+	if hookCommandPresent(preToolUse, worktreeGuardCommand) {
+		return false, nil
+	}
 
+	entry := map[string]any{
+		"matcher": worktreeGuardMatcher,
+		"hooks": []any{
+			map[string]any{
+				"type":    "command",
+				"command": worktreeGuardCommand,
+				"timeout": worktreeGuardTimeout,
+			},
+		},
+	}
+	// Prepend so the guard runs before other PreToolUse hooks, matching the
+	// ordering in plugin/hooks/hooks.json.
+	hooks["PreToolUse"] = append([]any{entry}, preToolUse...)
+
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		return false, fmt.Errorf("creating %s: %w", claudeDir, err)
+	}
 	data, err := json.MarshalIndent(settings, "", "  ")
 	if err != nil {
-		return fmt.Errorf("marshaling settings: %w", err)
+		return false, fmt.Errorf("marshaling settings: %w", err)
 	}
 	data = append(data, '\n')
 
 	tmp := settingsPath + ".tmp"
-	if err := os.WriteFile(tmp, data, 0644); err != nil {
-		return fmt.Errorf("writing temp file: %w", err)
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return false, fmt.Errorf("writing %s: %w", tmp, err)
 	}
-	return os.Rename(tmp, settingsPath)
+	if err := os.Rename(tmp, settingsPath); err != nil {
+		return false, fmt.Errorf("renaming %s: %w", tmp, err)
+	}
+	return true, nil
 }
 
-func Uninstall(projectDir string) error {
-	settingsPath := filepath.Join(projectDir, ".claude", "settings.json")
-
-	data, err := os.ReadFile(settingsPath)
-	if os.IsNotExist(err) {
-		return nil
-	} else if err != nil {
-		return err
+// hooksAndPreToolUse returns the settings["hooks"] object (creating it if
+// absent) and its "PreToolUse" array (empty if absent). It errors if either
+// existing value has an unexpected type, so a malformed file is never silently
+// overwritten.
+func hooksAndPreToolUse(settings map[string]any) (map[string]any, []any, error) {
+	hooksAny, ok := settings["hooks"]
+	if !ok || hooksAny == nil {
+		hooksAny = map[string]any{}
+		settings["hooks"] = hooksAny
 	}
-
-	var settings map[string]any
-	if err := json.Unmarshal(data, &settings); err != nil {
-		return fmt.Errorf("parsing settings.json: %w", err)
+	hooks, ok := hooksAny.(map[string]any)
+	if !ok {
+		return nil, nil, fmt.Errorf(`"hooks" is not an object`)
 	}
-
-	delete(settings, "hooks")
-
-	if len(settings) == 0 {
-		return os.Remove(settingsPath)
+	preAny, ok := hooks["PreToolUse"]
+	if !ok || preAny == nil {
+		return hooks, []any{}, nil
 	}
+	pre, ok := preAny.([]any)
+	if !ok {
+		return nil, nil, fmt.Errorf(`"hooks.PreToolUse" is not an array`)
+	}
+	return hooks, pre, nil
+}
 
-	out, err := json.MarshalIndent(settings, "", "  ")
-	if err != nil {
-		return err
+// hookCommandPresent reports whether any PreToolUse matcher already registers
+// the given hook command.
+func hookCommandPresent(preToolUse []any, command string) bool {
+	for _, m := range preToolUse {
+		matcher, ok := m.(map[string]any)
+		if !ok {
+			continue
+		}
+		entries, ok := matcher["hooks"].([]any)
+		if !ok {
+			continue
+		}
+		for _, h := range entries {
+			hook, ok := h.(map[string]any)
+			if !ok {
+				continue
+			}
+			if cmd, ok := hook["command"].(string); ok && cmd == command {
+				return true
+			}
+		}
 	}
-	out = append(out, '\n')
-	tmp := settingsPath + ".tmp"
-	if err := os.WriteFile(tmp, out, 0644); err != nil {
-		return err
-	}
-	return os.Rename(tmp, settingsPath)
+	return false
 }

--- a/cli/internal/install/install_test.go
+++ b/cli/internal/install/install_test.go
@@ -8,96 +8,147 @@ import (
 	"testing"
 )
 
-func TestInstall_CreatesNewFile(t *testing.T) {
-	dir := t.TempDir()
-	err := Install(dir, "/path/to/fellowship")
+func readSettings(t *testing.T, dir string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(dir, ".claude", "settings.local.json"))
 	if err != nil {
-		t.Fatalf("Install failed: %v", err)
-	}
-	path := filepath.Join(dir, ".claude", "settings.json")
-	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("settings.json not created: %v", err)
+		t.Fatalf("reading settings.json: %v", err)
 	}
 	var m map[string]any
-	json.Unmarshal(data, &m)
-	if _, ok := m["hooks"]; !ok {
-		t.Error("hooks key missing")
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("settings.json is not valid JSON: %v", err)
+	}
+	return m
+}
+
+func preToolUse(t *testing.T, m map[string]any) []any {
+	t.Helper()
+	hooks, ok := m["hooks"].(map[string]any)
+	if !ok {
+		t.Fatalf("hooks missing or wrong type: %T", m["hooks"])
+	}
+	pre, ok := hooks["PreToolUse"].([]any)
+	if !ok {
+		t.Fatalf("PreToolUse missing or wrong type: %T", hooks["PreToolUse"])
+	}
+	return pre
+}
+
+func TestEnsureWorktreeGuardHook_CreatesNewFile(t *testing.T) {
+	dir := t.TempDir()
+	changed, err := EnsureWorktreeGuardHook(dir)
+	if err != nil {
+		t.Fatalf("EnsureWorktreeGuardHook failed: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected changed=true when creating a new settings.json")
+	}
+	if !hookCommandPresent(preToolUse(t, readSettings(t, dir)), worktreeGuardCommand) {
+		t.Error("worktree-guard command not registered")
 	}
 }
 
-func TestInstall_MergesWithExisting(t *testing.T) {
+func TestEnsureWorktreeGuardHook_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := EnsureWorktreeGuardHook(dir); err != nil {
+		t.Fatalf("first install failed: %v", err)
+	}
+	before, _ := os.ReadFile(filepath.Join(dir, ".claude", "settings.local.json"))
+
+	changed, err := EnsureWorktreeGuardHook(dir)
+	if err != nil {
+		t.Fatalf("second install failed: %v", err)
+	}
+	if changed {
+		t.Error("expected changed=false on a repeat install")
+	}
+	after, _ := os.ReadFile(filepath.Join(dir, ".claude", "settings.local.json"))
+	if string(before) != string(after) {
+		t.Error("settings.json should be byte-identical after an idempotent call")
+	}
+
+	// Exactly one guard matcher — no duplication.
+	count := 0
+	for _, m := range preToolUse(t, readSettings(t, dir)) {
+		if hookCommandPresent([]any{m}, worktreeGuardCommand) {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly one guard matcher, got %d", count)
+	}
+}
+
+func TestEnsureWorktreeGuardHook_PreservesExistingSettingsAndHooks(t *testing.T) {
 	dir := t.TempDir()
 	claudeDir := filepath.Join(dir, ".claude")
-	os.MkdirAll(claudeDir, 0755)
-	os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte(`{"allowedTools":["Read"],"permissions":{"allow":true}}`), 0644)
+	os.MkdirAll(claudeDir, 0o755)
+	existing := `{
+	  "permissions": {"allow": ["Read"]},
+	  "hooks": {
+	    "PreToolUse": [
+	      {"matcher": "Bash", "hooks": [{"type": "command", "command": "echo other"}]}
+	    ],
+	    "PostToolUse": [
+	      {"matcher": "Skill", "hooks": [{"type": "command", "command": "echo post"}]}
+	    ]
+	  }
+	}`
+	os.WriteFile(filepath.Join(claudeDir, "settings.local.json"), []byte(existing), 0o644)
 
-	err := Install(dir, "/path/to/fellowship")
+	changed, err := EnsureWorktreeGuardHook(dir)
 	if err != nil {
-		t.Fatalf("Install failed: %v", err)
+		t.Fatalf("install failed: %v", err)
 	}
-	data, _ := os.ReadFile(filepath.Join(claudeDir, "settings.json"))
-	var m map[string]any
-	json.Unmarshal(data, &m)
-	if _, ok := m["hooks"]; !ok {
-		t.Error("hooks key missing after merge")
+	if !changed {
+		t.Fatal("expected changed=true when adding the guard to an existing file")
 	}
-	if _, ok := m["allowedTools"]; !ok {
-		t.Error("allowedTools lost during merge")
-	}
+
+	m := readSettings(t, dir)
 	if _, ok := m["permissions"]; !ok {
-		t.Error("permissions lost during merge")
+		t.Error("unrelated top-level key 'permissions' was dropped")
+	}
+	hooks := m["hooks"].(map[string]any)
+	if _, ok := hooks["PostToolUse"]; !ok {
+		t.Error("PostToolUse hooks were dropped")
+	}
+	pre := preToolUse(t, m)
+	if !hookCommandPresent(pre, worktreeGuardCommand) {
+		t.Error("guard command not registered")
+	}
+	if !hookCommandPresent(pre, "echo other") {
+		t.Error("pre-existing PreToolUse hook was dropped")
+	}
+	// Guard is prepended so it runs first.
+	if !hookCommandPresent([]any{pre[0]}, worktreeGuardCommand) {
+		t.Error("guard should be the first PreToolUse matcher")
 	}
 }
 
-func TestUninstall_RemovesHooksKeepsRest(t *testing.T) {
+func TestEnsureWorktreeGuardHook_MalformedHooksIsNotClobbered(t *testing.T) {
 	dir := t.TempDir()
 	claudeDir := filepath.Join(dir, ".claude")
-	os.MkdirAll(claudeDir, 0755)
-	os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte(`{"hooks":{"PreToolUse":[]},"allowedTools":["Read"]}`), 0644)
+	os.MkdirAll(claudeDir, 0o755)
+	original := `{"hooks": "not-an-object"}`
+	path := filepath.Join(claudeDir, "settings.local.json")
+	os.WriteFile(path, []byte(original), 0o644)
 
-	err := Uninstall(dir)
-	if err != nil {
-		t.Fatalf("Uninstall failed: %v", err)
+	changed, err := EnsureWorktreeGuardHook(dir)
+	if err == nil {
+		t.Fatal("expected an error for malformed hooks, got nil")
 	}
-	data, _ := os.ReadFile(filepath.Join(claudeDir, "settings.json"))
-	var m map[string]any
-	json.Unmarshal(data, &m)
-	if _, ok := m["hooks"]; ok {
-		t.Error("hooks key should be removed")
+	if changed {
+		t.Error("changed must be false when refusing a malformed file")
 	}
-	if _, ok := m["allowedTools"]; !ok {
-		t.Error("allowedTools should be preserved")
-	}
-}
-
-func TestUninstall_RemovesFileWhenHooksOnly(t *testing.T) {
-	dir := t.TempDir()
-	claudeDir := filepath.Join(dir, ".claude")
-	os.MkdirAll(claudeDir, 0755)
-	path := filepath.Join(claudeDir, "settings.json")
-	os.WriteFile(path, []byte(`{"hooks":{"PreToolUse":[]}}`), 0644)
-
-	Uninstall(dir)
-	if _, err := os.Stat(path); !os.IsNotExist(err) {
-		t.Error("file should be removed when hooks were the only key")
+	data, _ := os.ReadFile(path)
+	if string(data) != original {
+		t.Error("malformed settings.json must be left untouched")
 	}
 }
 
-func TestUninstall_NoopsWhenMissing(t *testing.T) {
-	dir := t.TempDir()
-	err := Uninstall(dir)
-	if err != nil {
-		t.Fatalf("Uninstall should noop, got: %v", err)
-	}
-}
-
-func TestInstall_HookCommandsUseBinPath(t *testing.T) {
-	dir := t.TempDir()
-	Install(dir, "/custom/path/fellowship")
-	data, _ := os.ReadFile(filepath.Join(dir, ".claude", "settings.json"))
-	s := string(data)
-	if !strings.Contains(s, "/custom/path/fellowship") {
-		t.Error("hook commands should use the provided bin path")
+func TestEnsureWorktreeGuardHook_CommandMatchesHooksJSON(t *testing.T) {
+	// Guards against drift from plugin/hooks/hooks.json.
+	if !strings.Contains(worktreeGuardCommand, "fellowship hook worktree-guard") {
+		t.Errorf("guard command %q should invoke `fellowship hook worktree-guard`", worktreeGuardCommand)
 	}
 }

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -14,6 +14,16 @@
     ],
     "PreToolUse": [
       {
+        "matcher": "Edit|Write|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${HOME}/.claude/fellowship/bin/fellowship hook worktree-guard",
+            "timeout": 5
+          }
+        ]
+      },
+      {
         "matcher": "Edit|Write|Bash|Agent|Skill|NotebookEdit",
         "hooks": [
           {

--- a/plugin/skills/fellowship/SKILL.md
+++ b/plugin/skills/fellowship/SKILL.md
@@ -121,9 +121,30 @@ No built-in templates ship with fellowship. Use `/scribe` to create them. Parse 
 
 **Template selection:** Explicit (`template: <name>`) > auto-suggest (keyword matching) > no template.
 
-### Gate Hook Propagation
+### Gate Hook Propagation & Isolation Pre-flight (REQUIRED before spawning)
 
-Plugin hooks only fire in Gandalf's session — teammates spawned via the Agent tool do not inherit them. A `SessionStart` hook in the plugin automatically creates `.claude/settings.json` with project-level hooks when the plugin loads. This ensures teammates inherit gate enforcement without any manual setup.
+Plugin hooks only fire in Gandalf's session — teammates spawned via the Agent
+tool do NOT inherit them, and there is **no auto-install** of teammate hooks.
+For hooks to fire in teammate sessions they must be registered in a project
+`.claude/settings.json` that lives on the base branch, so fresh worktrees
+contain it.
+
+Before spawning any quest, Gandalf MUST:
+
+1. Verify (or create) a project `.claude/settings.json` that registers the
+   `worktree-guard` PreToolUse hook (matcher `Edit|Write|NotebookEdit`, command
+   `${HOME}/.claude/fellowship/bin/fellowship hook worktree-guard`). Commit it to
+   the base branch so every worktree branched from it inherits the hook.
+2. Confirm the guard binary is on PATH — `~/.claude/fellowship/bin/fellowship
+   version` should succeed.
+3. Confirm the fellowship state store exists (a fellowship has been initialized
+   via `fellowship state init`).
+
+The guard is **inert unless a fellowship is active**, so installing it is always
+safe — it never blocks work outside a fellowship. Note that `isolation:
+"worktree"` (see "Spawn a Quest") is the **primary** isolation guarantee; the
+`worktree-guard` hook is defense-in-depth for the case where a teammate is
+mis-placed in the main tree.
 
 ### Spawn a Quest
 
@@ -143,7 +164,17 @@ If no issue references are found, `{issue_context}` is substituted with an empty
    - `team_name`: the fellowship team name
    - `subagent_type: "general-purpose"`
    - `name`: `"quest-{n}"` or a descriptive name like `"quest-auth-bug"`
-   - Do NOT pass `isolation: "worktree"` — the teammate creates its own worktree during quest Phase 0.
+   - **`isolation: "worktree"` — REQUIRED.** The lead creates the teammate's
+     isolation via the harness; the teammate is placed in its own git worktree
+     off the base branch and physically cannot touch the main working tree.
+     Do NOT rely on the teammate creating its own worktree in quest Phase 0 —
+     that is advisory and fails silently if the teammate skips it, dropping the
+     quest into the shared main tree. Isolation is the lead's responsibility and
+     must be structural, not trusted.
+   - **Never tell a teammate it is "already isolated" unless you actually
+     created its worktree.** The spawn prompt requires the teammate to
+     self-verify isolation before its first write (see spawn-prompts.md); the
+     `worktree-guard` PreToolUse hook is the fail-closed backstop.
 
 **Errand persistence:** After spawning, write initial errands via `~/.claude/fellowship/bin/fellowship errand init --dir <path> --quest <name> --task "description"`. Add errands to running quests: `~/.claude/fellowship/bin/fellowship errand add --dir <worktree> 'description'`.
 

--- a/plugin/skills/fellowship/SKILL.md
+++ b/plugin/skills/fellowship/SKILL.md
@@ -141,10 +141,12 @@ Before spawning any quest, Gandalf MUST:
    via `fellowship state init`).
 
 The guard is **inert unless a fellowship is active**, so installing it is always
-safe — it never blocks work outside a fellowship. Note that `isolation:
-"worktree"` (see "Spawn a Quest") is the **primary** isolation guarantee; the
-`worktree-guard` hook is defense-in-depth for the case where a teammate is
-mis-placed in the main tree.
+safe — it never blocks work outside a fellowship. Isolation itself is provisioned
+and VERIFIED by the lead (explicit `git worktree add` is the reliable path — the
+harness `isolation` flag can silently no-op; see "Spawn a Quest"). The
+`worktree-guard` hook and the teammate's self-check are the fail-closed
+backstops that catch a mis-placed teammate regardless of how isolation was
+provisioned.
 
 ### Spawn a Quest
 
@@ -164,17 +166,30 @@ If no issue references are found, `{issue_context}` is substituted with an empty
    - `team_name`: the fellowship team name
    - `subagent_type: "general-purpose"`
    - `name`: `"quest-{n}"` or a descriptive name like `"quest-auth-bug"`
-   - **`isolation: "worktree"` — REQUIRED.** The lead creates the teammate's
-     isolation via the harness; the teammate is placed in its own git worktree
-     off the base branch and physically cannot touch the main working tree.
-     Do NOT rely on the teammate creating its own worktree in quest Phase 0 —
-     that is advisory and fails silently if the teammate skips it, dropping the
-     quest into the shared main tree. Isolation is the lead's responsibility and
-     must be structural, not trusted.
-   - **Never tell a teammate it is "already isolated" unless you actually
-     created its worktree.** The spawn prompt requires the teammate to
-     self-verify isolation before its first write (see spawn-prompts.md); the
-     `worktree-guard` PreToolUse hook is the fail-closed backstop.
+   - **Isolation is the LEAD's job to PROVISION and VERIFY — never a flag to
+     trust.** The `Task`/Agent `isolation: "worktree"` param has been observed to
+     silently no-op for background quest teammates (no worktree is created; the
+     teammate lands in the main repo root). Do NOT assume it worked, and do NOT
+     rely on the teammate creating its own worktree in quest Phase 0 — that is
+     advisory and fails silently if skipped, dropping the quest into the shared
+     main tree.
+   - **Preferred reliable mechanism:** before spawning, the lead explicitly runs
+     `git worktree add -b <branch> <path> <base>` with `<path>` OUTSIDE the main
+     tree, provisions dependencies so the teammate's tests run (e.g. symlink or
+     install `node_modules`), and directs the teammate into that worktree via its
+     spawn prompt. Passing the harness `isolation` flag MAY additionally work but
+     MUST be verified with `git worktree list` (and the teammate's self-check) —
+     never assumed.
+   - **Then VERIFY before the teammate writes.** After provisioning, confirm the
+     worktree exists (`git worktree list`) and that its path is not the main root.
+     Never tell a teammate it is "already isolated" unless you have verified its
+     worktree exists.
+   - **Two safeguards catch the bug regardless of how isolation was provisioned:**
+     (1) the teammate's mandatory isolation SELF-CHECK before its first write —
+     top-level must differ from the main root, else STOP and message the lead
+     (see spawn-prompts.md); and (2) the fail-closed `worktree-guard` PreToolUse
+     hook, which blocks source writes from the main tree during an active
+     fellowship. These are what actually prevent the regression.
 
 **Errand persistence:** After spawning, write initial errands via `~/.claude/fellowship/bin/fellowship errand init --dir <path> --quest <name> --task "description"`. Add errands to running quests: `~/.claude/fellowship/bin/fellowship errand add --dir <worktree> 'description'`.
 

--- a/plugin/skills/fellowship/SKILL.md
+++ b/plugin/skills/fellowship/SKILL.md
@@ -124,18 +124,28 @@ No built-in templates ship with fellowship. Use `/scribe` to create them. Parse 
 ### Gate Hook Propagation & Isolation Pre-flight (REQUIRED before spawning)
 
 Plugin hooks only fire in Gandalf's session — teammates spawned via the Agent
-tool do NOT inherit them, and there is **no auto-install** of teammate hooks.
-For hooks to fire in teammate sessions they must be registered in a project
-`.claude/settings.json` that lives on the base branch, so fresh worktrees
-contain it.
+tool do NOT inherit them. For the `worktree-guard` to fire in a session, a
+`.claude/settings.local.json` registering it must be present at that session's
+root.
+
+`fellowship state init` writes that file for you: it merges the `worktree-guard`
+PreToolUse hook into the project `.claude/settings.local.json` (preserving any
+existing settings; idempotent). `settings.local.json` is **git-ignored**, so
+this touches no git history and leaves no untracked file. Pass
+`--skip-hook-install` to opt out (e.g. if you manage settings yourself).
+
+This alone catches the primary bug: a teammate that lands in the **main repo
+root** (the isolation failure) reads the main tree's `settings.local.json`, so
+the guard fires and blocks. To also arm correctly-placed teammates, the lead
+copies `.claude/settings.local.json` into each new worktree right after
+`git worktree add` (see "Spawn a Quest"). No commit, ever.
 
 Before spawning any quest, Gandalf MUST:
 
-1. Verify (or create) a project `.claude/settings.json` that registers the
-   `worktree-guard` PreToolUse hook (matcher `Edit|Write|NotebookEdit`, command
-   `${HOME}/.claude/fellowship/bin/fellowship hook worktree-guard`). Commit it to
-   the base branch so every worktree branched from it inherits the hook.
-2. Confirm the guard binary is on PATH — `~/.claude/fellowship/bin/fellowship
+1. Confirm `state init` wrote the hook — its output reads "Registered
+   worktree-guard hook in .claude/settings.local.json" (or the file already had
+   it).
+2. Confirm the guard binary is present — `~/.claude/fellowship/bin/fellowship
    version` should succeed.
 3. Confirm the fellowship state store exists (a fellowship has been initialized
    via `fellowship state init`).
@@ -176,10 +186,12 @@ If no issue references are found, `{issue_context}` is substituted with an empty
    - **Preferred reliable mechanism:** before spawning, the lead explicitly runs
      `git worktree add -b <branch> <path> <base>` with `<path>` OUTSIDE the main
      tree, provisions dependencies so the teammate's tests run (e.g. symlink or
-     install `node_modules`), and directs the teammate into that worktree via its
-     spawn prompt. Passing the harness `isolation` flag MAY additionally work but
-     MUST be verified with `git worktree list` (and the teammate's self-check) —
-     never assumed.
+     install `node_modules`), copies `.claude/settings.local.json` into the new
+     worktree (`mkdir -p <path>/.claude && cp .claude/settings.local.json
+     <path>/.claude/`) so the `worktree-guard` hook is armed there, and directs
+     the teammate into that worktree via its spawn prompt. Passing the harness
+     `isolation` flag MAY additionally work but MUST be verified with
+     `git worktree list` (and the teammate's self-check) — never assumed.
    - **Then VERIFY before the teammate writes.** After provisioning, confirm the
      worktree exists (`git worktree list`) and that its path is not the main root.
      Never tell a teammate it is "already isolated" unless you have verified its

--- a/plugin/skills/fellowship/resources/spawn-prompts.md
+++ b/plugin/skills/fellowship/resources/spawn-prompts.md
@@ -10,8 +10,9 @@ YOUR TASK: {task_description}
 
 INSTRUCTIONS:
 1. Run /quest to execute this task through the full quest lifecycle
-2. ISOLATION SELF-CHECK (do this BEFORE any Edit/Write/commit): the lead
-   spawned you in your own git worktree. Confirm it before touching anything.
+2. ISOLATION SELF-CHECK (do this BEFORE any Edit/Write/commit): the lead should
+   have placed you in your own git worktree, but isolation provisioning can
+   silently fail — do NOT assume it worked. Verify before touching anything.
    Run `git rev-parse --show-toplevel` and `git rev-parse --git-common-dir`.
    The main repo root is the PARENT of the common git dir. Your top-level MUST
    NOT equal the main repo root. If it IS the main root, STOP — do not edit,
@@ -125,8 +126,9 @@ INSTRUCTIONS:
    - In Phase 0 (Onboard), copy the plan file to .fellowship/plan.md
    - The quest skill will detect this file and skip Research + Plan,
      starting directly at Phase 3 (Implement)
-2. ISOLATION SELF-CHECK (do this BEFORE any Edit/Write/commit): the lead
-   spawned you in your own git worktree. Confirm it before touching anything.
+2. ISOLATION SELF-CHECK (do this BEFORE any Edit/Write/commit): the lead should
+   have placed you in your own git worktree, but isolation provisioning can
+   silently fail — do NOT assume it worked. Verify before touching anything.
    Run `git rev-parse --show-toplevel` and `git rev-parse --git-common-dir`.
    The main repo root is the PARENT of the common git dir. Your top-level MUST
    NOT equal the main repo root. If it IS the main root, STOP — do not edit,
@@ -216,8 +218,9 @@ SCOUT FINDINGS CONTENT:
 
 INSTRUCTIONS:
 1. Run /quest to execute this task through the full quest lifecycle
-2. ISOLATION SELF-CHECK (do this BEFORE any Edit/Write/commit): the lead
-   spawned you in your own git worktree. Confirm it before touching anything.
+2. ISOLATION SELF-CHECK (do this BEFORE any Edit/Write/commit): the lead should
+   have placed you in your own git worktree, but isolation provisioning can
+   silently fail — do NOT assume it worked. Verify before touching anything.
    Run `git rev-parse --show-toplevel` and `git rev-parse --git-common-dir`.
    The main repo root is the PARENT of the common git dir. Your top-level MUST
    NOT equal the main repo root. If it IS the main root, STOP — do not edit,

--- a/plugin/skills/fellowship/resources/spawn-prompts.md
+++ b/plugin/skills/fellowship/resources/spawn-prompts.md
@@ -10,8 +10,16 @@ YOUR TASK: {task_description}
 
 INSTRUCTIONS:
 1. Run /quest to execute this task through the full quest lifecycle
-2. Quest Phase 0 will create your isolated worktree using the branch
-   naming config — make changes freely once isolation is set up
+2. ISOLATION SELF-CHECK (do this BEFORE any Edit/Write/commit): the lead
+   spawned you in your own git worktree. Confirm it before touching anything.
+   Run `git rev-parse --show-toplevel` and `git rev-parse --git-common-dir`.
+   The main repo root is the PARENT of the common git dir. Your top-level MUST
+   NOT equal the main repo root. If it IS the main root, STOP — do not edit,
+   do not commit — and message the lead that you were not isolated. Only
+   proceed once you have confirmed your top-level is a distinct worktree path.
+   Note: the fail-closed `worktree-guard` hook blocks source writes from the
+   main tree — a block is PROOF you are mis-placed, not an obstacle to route
+   around.
 3. Gate handling — gates are enforced by plugin hooks via a state file
    (.fellowship/quest-state.json). The hooks structurally block your tools
    after gate submission. Here is how it works:
@@ -117,8 +125,16 @@ INSTRUCTIONS:
    - In Phase 0 (Onboard), copy the plan file to .fellowship/plan.md
    - The quest skill will detect this file and skip Research + Plan,
      starting directly at Phase 3 (Implement)
-2. Quest Phase 0 will create your isolated worktree using the branch
-   naming config — make changes freely once isolation is set up
+2. ISOLATION SELF-CHECK (do this BEFORE any Edit/Write/commit): the lead
+   spawned you in your own git worktree. Confirm it before touching anything.
+   Run `git rev-parse --show-toplevel` and `git rev-parse --git-common-dir`.
+   The main repo root is the PARENT of the common git dir. Your top-level MUST
+   NOT equal the main repo root. If it IS the main root, STOP — do not edit,
+   do not commit — and message the lead that you were not isolated. Only
+   proceed once you have confirmed your top-level is a distinct worktree path.
+   Note: the fail-closed `worktree-guard` hook blocks source writes from the
+   main tree — a block is PROOF you are mis-placed, not an obstacle to route
+   around.
 3. Gate handling — gates are enforced by plugin hooks via a state file
    (.fellowship/quest-state.json). The hooks structurally block your tools
    after gate submission. Here is how it works:
@@ -200,8 +216,16 @@ SCOUT FINDINGS CONTENT:
 
 INSTRUCTIONS:
 1. Run /quest to execute this task through the full quest lifecycle
-2. Quest Phase 0 will create your isolated worktree using the branch
-   naming config — make changes freely once isolation is set up
+2. ISOLATION SELF-CHECK (do this BEFORE any Edit/Write/commit): the lead
+   spawned you in your own git worktree. Confirm it before touching anything.
+   Run `git rev-parse --show-toplevel` and `git rev-parse --git-common-dir`.
+   The main repo root is the PARENT of the common git dir. Your top-level MUST
+   NOT equal the main repo root. If it IS the main root, STOP — do not edit,
+   do not commit — and message the lead that you were not isolated. Only
+   proceed once you have confirmed your top-level is a distinct worktree path.
+   Note: the fail-closed `worktree-guard` hook blocks source writes from the
+   main tree — a block is PROOF you are mis-placed, not an obstacle to route
+   around.
 3. Gate handling — gates are enforced by plugin hooks via a state file
    (.fellowship/quest-state.json). The hooks structurally block your tools
    after gate submission. Here is how it works:


### PR DESCRIPTION
## Root cause

Fellowship spawns quest teammates that must run in isolated git worktrees. Isolation was only **advisory** — teammates were trusted to self-create a worktree in quest Phase 0, and when that was skipped they wrote source directly into the **main working tree** and committed to the base branch. Two empirical findings drove the fix:

1. The Agent/Task `isolation:"worktree"` param **silently no-ops** for background quest teammates (no worktree created; teammate lands in the main root). The flag must never be trusted — the lead **provisions and verifies** isolation via explicit `git worktree add` outside the main tree.
2. A teammate self-check plus a fail-closed guard hook are what actually prevent the bug.

## Three-layer defense

1. **Lead provisions AND verifies** isolation via explicit `git worktree add` (docs: `SKILL.md`, `spawn-prompts.md`).
2. **Teammate isolation self-check** before its first write (every spawn-prompt variant).
3. **Fail-closed `worktree-guard` hook** — during an *active* fellowship, blocks Edit/Write/NotebookEdit on a source path when the session top-level *is* the main repo root. Allows worktree writes, coordination dirs, non-mutating tools, and Bash (the lead's merges).

## Reaching teammates without touching git history

Teammate sessions don't inherit plugin hooks, so `state init` merges the guard into git-ignored **`.claude/settings.local.json`** (no commit, no untracked file). The main-tree file catches a teammate mis-placed in the main root; the lead copies it into each worktree at spawn.

## Lead cd-guard (addresses "lead keeps getting stuck")

The existing cd-guard only recognized `.claude/worktrees/`, but this PR provisions worktrees **outside** the main tree — so a bare `cd` into one slipped through, moving the lead onto quest state and inheriting that quest's gate/hold blocks. The guard now blocks a bare `cd`/`pushd` into **any live git worktree** (`git worktree list`, main root excluded), plus the legacy path; scoped `cd … && cmd` stays allowed.

## Review fixes (this PR was self-reviewed; findings addressed)

- 🔴 **Blocker:** the guard treated "a fellowship DB row exists" as "active", but that row is never deleted — so after any `state init`, main-tree edits were blocked *forever*. "Active" is now **"a quest worktree exists on disk"** — self-healing, no cleanup command needed.
- 🟠 **dataDir:** the coordination-dir exemption hardcoded `.fellowship`; it now honors the configurable `datadir.Name()`.
- 🟡 Stale `--skip-hook-install` help text; `CanonicalPath` de-duplicated into the `hooks` package.

## Also

- **CONTRIBUTING.md** rewritten for the Go CLI (was describing removed bash hooks).
- **gofmt** — pre-existing unformatted files cleaned so `gofmt -l .` is green tree-wide.

## Verification

`gofmt -l .` clean · `go vet ./...` clean · `go test ./...` all pass (14 packages), with new tests for the installer, custom `dataDir`, and out-of-tree cd detection. End-to-end verified with the built binary: guard blocks a mis-placed main-root write only while a quest worktree is live; self-heals when worktrees are removed; cd-guard blocks bare `cd` into out-of-tree worktrees while allowing scoped commands and main-tree navigation.

## Follow-ups (not in this PR)

- Remaining review notes (guard doesn't cover Bash writes by a mis-placed teammate; guard keys on session vs target location; hooks.json↔install.go matcher duplication; per-Edit hot-path git/DB overhead).
- Changelog/openspec: added by the maintainer at release time (v2.0.0 already released; changelog is append-only).
- Plugin cache: reinstall after merge to drop the throwaway bash `worktree-guard.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)