### PR TITLE
Architecture review fixes: followability bugs, model routing, spawn-prompt dedup, docs refresh

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -8,7 +8,7 @@
   "repository": "https://github.com/justinjdev/fellowship",
   "license": "MIT",
   "skills": ["./plugin/skills/"],
-  "agents": ["./plugin/agents/balrog.md", "./plugin/agents/palantir.md", "./plugin/agents/quest-runner.md", "./plugin/agents/scout.md"],
+  "agents": ["./plugin/agents/balrog.md", "./plugin/agents/palantir.md", "./plugin/agents/quest-runner.md", "./plugin/agents/scout.md", "./plugin/agents/validator.md"],
   "commands": ["./plugin/commands/"],
   "hooks": "./plugin/hooks/hooks.json"
 }

--- a/.claude/commands/validate-docs.md
+++ b/.claude/commands/validate-docs.md
@@ -8,7 +8,7 @@ description: Validate that site and README documentation is current. Report-only
 
 ## Overview
 
-Checks that documentation is current against the codebase: the site changelog, README changelog, skills/commands page, agents page, and marketplace description. Collects all findings across Steps 1–5, then emits a single structured report in Step 6. Does not modify any files — report-only.
+Checks that documentation is current against the codebase: the site changelog, README changelog, skills/commands page, agents page, marketplace description, and config schema. Collects all findings across Steps 1–6, then emits a single structured report in Step 7. Does not modify any files — report-only.
 
 ## Process
 
@@ -55,9 +55,24 @@ Find the fellowship plugin entry and check that:
 
 Flag any mismatch.
 
-### Step 6: Report
+### Step 6: Config schema
 
-Emit all findings collected from Steps 1–5. Do not output inline findings during earlier steps — accumulate them and report here.
+Read the `## Schema Reference` table in `plugin/commands/settings.md` — the canonical config schema. If the file or section does not exist, flag it as missing and continue to Step 7.
+
+Extract the full set of config keys (e.g. `branch.pattern`, `gates.autoApprove`, `models.quest`) with their documented defaults. Cross-reference each key against both documentation surfaces:
+
+1. **README** — the Configuration section's settings table AND its example JSON block
+2. **Site** — `site/src/routes/configuration/+page.svelte` (the settings array and its example JSON)
+
+Flag:
+- Any schema key missing from the README table or example JSON
+- Any schema key missing from the site configuration page
+- Any key documented in README or on the site that is absent from the settings.md schema (stale key)
+- Default values that disagree between settings.md and either surface
+
+### Step 7: Report
+
+Emit all findings collected from Steps 1–6. Do not output inline findings during earlier steps — accumulate them and report here.
 
 If no issues:
 
@@ -69,6 +84,7 @@ Docs validation
   Skills page     ✓
   Agents page     ✓
   Marketplace     ✓
+  Config schema   ✓
 
   ✓ All docs current
 ```
@@ -83,12 +99,13 @@ Docs validation
   Skills page     ✗ missing: some-skill
   Agents page     ✓
   Marketplace     ✗ description says 2 agents, found 4
+  Config schema   ✗ issues.autoClose missing from README table
 
-  2 issues found
+  3 issues found
 ```
 
 ## Key Principles
 
 - **Report-only.** Never modify any files. Flag issues; do not fix them.
-- **Accumulate before reporting.** Collect all findings across Steps 1–5, then emit the single structured report in Step 6.
+- **Accumulate before reporting.** Collect all findings across Steps 1–6, then emit the single structured report in Step 7.
 - **Graceful degradation.** If a file or data source is missing, flag it as missing, note it in the report, and continue to the next step.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,14 @@ Add this hook to `.claude/settings.local.json` in repos where you use fellowship
 }
 ```
 
-Also add `.fellowship/` to your `.gitignore` — checkpoints are local ephemeral state. If you have configured a custom `dataDir` in `~/.claude/fellowship.json`, use that directory name instead.
+Also add the fellowship data directory to your `.gitignore` — checkpoints and state are local ephemeral files. Keep `.fellowship/config.json` trackable, though: it holds committable team-shared settings (see `/settings`):
+
+```gitignore
+.fellowship/*
+!.fellowship/config.json
+```
+
+If you have configured a custom `dataDir` in `~/.claude/fellowship.json`, use that directory name instead.
 
 ### Configuration (Optional)
 
@@ -167,6 +174,7 @@ Commands are user-invoked only — Claude never calls them automatically, so the
 | **quest-runner** | Quest execution agent. Uses the fellowship CLI for gate management, status checks, and phase transitions. |
 | **balrog** | Adversarial validation agent spawned by quest between Implement and Review. Analyzes the diff for failure modes, writes and runs targeted test cases, and delivers a severity-ranked findings report. |
 | **scout** | Research & analysis agent spawned as a fellowship teammate for read-only investigation — no code edits, no git operations. Defaults to the `sonnet` model. |
+| **validator** | Read-only adversarial validator spawned by scout to verify research findings against the actual code (CONFIRMED/CONTESTED/UNVERIFIED). Tools restricted to Read/Glob/Grep. Defaults to the `sonnet` model. |
 
 ## How It Works
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,17 @@ Create `~/.claude/fellowship.json` in your personal Claude directory to customiz
   "palantir": {
     "enabled": true,
     "minQuests": 2
+  },
+  "issues": {
+    "autoClose": true
+  },
+  "models": {
+    "quest": null,
+    "scout": null,
+    "palantir": null,
+    "balrog": null,
+    "explore": null,
+    "validator": null
   }
 }
 ```
@@ -108,10 +119,19 @@ Create `~/.claude/fellowship.json` in your personal Claude directory to customiz
 | `pr.template` | `null` | PR body template string. Supports `{task}`, `{summary}`, and `{changes}` placeholders. |
 | `palantir.enabled` | `true` | Whether to spawn a palantir monitoring agent during fellowships. |
 | `palantir.minQuests` | `2` | Minimum active quests before palantir is spawned. |
+| `issues.autoClose` | `true` | When true, `/missive` includes `Closes #N` in PR keywords so issues close on merge. |
+| `models.quest` | `null` | Model for quest teammates. A model alias (`haiku`, `sonnet`, `opus`), a full model ID, or `"inherit"`. `null` = built-in default: inherit the session model. |
+| `models.scout` | `null` | Model for scout teammates. Same valid values. `null` = built-in default: `sonnet`. |
+| `models.palantir` | `null` | Model for the palantir monitor. Same valid values. `null` = built-in default: `haiku`. |
+| `models.balrog` | `null` | Model for balrog adversarial review. Same valid values. `null` = built-in default: inherit the session model. |
+| `models.explore` | `null` | Model for Explore scan subagents spawned by quest, scout, and council. Same valid values. `null` = built-in default: `haiku`. |
+| `models.validator` | `null` | Model for scout's validation subagent. Same valid values. `null` = built-in default: `sonnet`. |
 
 The config is read at fellowship startup and quest onboard (Phase 0). Changes to the file take effect on the next fellowship or quest invocation.
 
 ## Skills
+
+Skills are invoked automatically by Claude as part of a workflow (quest phases, context compression, etc.) — you can also invoke any of them directly with `/name`.
 
 | Skill | Purpose |
 |-------|---------|
@@ -122,16 +142,31 @@ The config is read at fellowship startup and quest onboard (Phase 0). Changes to
 | `/gather-lore` | Studies reference files to extract conventions before writing code. Prevents "wrong approach" rework. |
 | `/lembas` | Context compression between phases. Keeps the context window in the reasoning sweet spot. |
 | `/warden` | Pre-PR convention review. Compares changes against reference files and documented patterns. |
+| `/missive` | Fetches GitHub issue context for quest spawning — title, body, labels, comments, branch suggestions, and PR close keywords. |
+| `/retro` | Post-fellowship retrospective. Analyzes gate history, palantir alerts, and quest metrics, then recommends configuration improvements. |
+| `/lorebook` | Loads phase-specific guidance from an assigned quest template at the start of each quest phase. |
+
+## Commands
+
+Commands are user-invoked only — Claude never calls them automatically, so they carry no base context cost.
+
+| Command | Purpose |
+|---------|---------|
 | `/chronicle` | One-time codebase bootstrapping. Walks through your project to extract conventions into CLAUDE.md. |
+| `/guide` | Interactive, learn-by-doing walkthrough of fellowship using a real task on your codebase. |
 | `/red-book` | Post-PR convention capture. Extracts conventions from reviewer comments and adds them to CLAUDE.md. |
+| `/rekindle` | Recovers a fellowship after a session crash — scans worktrees and state files, then re-spawns Gandalf with recovered context. |
+| `/scribe` | Creates a reusable quest template that encodes project-specific rules and conventions into phase guidance. |
 | `/settings` | View or edit fellowship settings (`~/.claude/fellowship.json`). Interactive setup for all configuration options. |
 
 ## Agents
 
 | Agent | Role |
 |-------|------|
-| **palantir** | Background monitor during fellowship execution. Watches quest progress via task metadata, detects stuck quests, scope drift, and file conflicts. Reports to Gandalf. |
+| **palantir** | Background monitor during fellowship execution. Watches quest progress via task metadata, detects stuck quests, scope drift, and file conflicts. Reports to Gandalf. Defaults to the `haiku` model. |
 | **quest-runner** | Quest execution agent. Uses the fellowship CLI for gate management, status checks, and phase transitions. |
+| **balrog** | Adversarial validation agent spawned by quest between Implement and Review. Analyzes the diff for failure modes, writes and runs targeted test cases, and delivers a severity-ranked findings report. |
+| **scout** | Research & analysis agent spawned as a fellowship teammate for read-only investigation — no code edits, no git operations. Defaults to the `sonnet` model. |
 
 ## How It Works
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Fellowship's `/quest` skill orchestrates skills from these plugins. Install them
 | **superpowers** | `using-git-worktrees`, `test-driven-development`, `verification-before-completion`, `finishing-a-development-branch` | Onboard, Implement, Review, Complete |
 | **pr-review-toolkit** | `review-pr` | Review |
 
-These are referenced by name in skill prompts. If a dependency isn't installed, Claude will skip that step rather than fail — but you lose the discipline that step provides.
+These are referenced by name in skill prompts. If a dependency isn't installed, Claude performs the step's goal manually and notes the substitution in its output — but you lose the structured discipline the dedicated skill provides.
 
 ```
 /plugin marketplace add obra/superpowers-marketplace
@@ -114,17 +114,17 @@ Create `~/.claude/fellowship.json` in your personal Claude directory to customiz
 | `branch.ticketPattern` | `"[A-Z]+-\\d+"` | Regex to extract ticket IDs from quest descriptions. Default matches Jira-style IDs (e.g., `PROJ-123`). |
 | `worktree.enabled` | `true` | Whether quests create isolated worktrees. Set to `false` to work on the current branch. |
 | `worktree.directory` | `null` | Parent directory for worktrees. `null` uses Claude Code's default (`.claude/worktrees/`). |
-| `gates.autoApprove` | `[]` | Gate names to auto-approve: `"Research"`, `"Plan"`, `"Implement"`, `"Review"`, `"Complete"`. Gates not listed still surface to you for approval. |
+| `gates.autoApprove` | `[]` | Gate names to auto-approve: `"Onboard"`, `"Research"`, `"Plan"`, `"Implement"`, `"Adversarial"`, `"Review"` (the phase being left — `"Research"` auto-approves Research→Plan). Gates not listed still surface to you for approval. |
 | `pr.draft` | `false` | Create PRs as drafts. |
 | `pr.template` | `null` | PR body template string. Supports `{task}`, `{summary}`, and `{changes}` placeholders. |
 | `palantir.enabled` | `true` | Whether to spawn a palantir monitoring agent during fellowships. |
 | `palantir.minQuests` | `2` | Minimum active quests before palantir is spawned. |
 | `issues.autoClose` | `true` | When true, `/missive` includes `Closes #N` in PR keywords so issues close on merge. |
-| `models.quest` | `null` | Model for quest teammates. A model alias (`haiku`, `sonnet`, `opus`), a full model ID, or `"inherit"`. `null` = built-in default: inherit the session model. |
+| `models.quest` | `null` | Model for quest teammates. Valid values: `"haiku"`, `"sonnet"`, `"opus"` (aliases only — spawn parameters accept neither `"inherit"` nor full model IDs; leave `null` to inherit). `null` = built-in default: inherit the session model. |
 | `models.scout` | `null` | Model for scout teammates. Same valid values. `null` = built-in default: `sonnet`. |
 | `models.palantir` | `null` | Model for the palantir monitor. Same valid values. `null` = built-in default: `haiku`. |
 | `models.balrog` | `null` | Model for balrog adversarial review. Same valid values. `null` = built-in default: inherit the session model. |
-| `models.explore` | `null` | Model for Explore scan subagents spawned by quest, scout, and council. Same valid values. `null` = built-in default: `haiku`. |
+| `models.explore` | `null` | Model for Explore scan subagents spawned by quest, scout, council, and guide. Same valid values. `null` = built-in default: `haiku`. |
 | `models.validator` | `null` | Model for scout's validation subagent. Same valid values. `null` = built-in default: `sonnet`. |
 
 The config is read at fellowship startup and quest onboard (Phase 0). Changes to the file take effect on the next fellowship or quest invocation.
@@ -177,6 +177,7 @@ Phase 0: Onboard    → worktree isolation + /council context loading
 Phase 1: Research   → explore agents + /gather-lore
 Phase 2: Plan       → plan mode with file:line references + user approval
 Phase 3: Implement  → TDD (red-green-refactor)
+Phase 3.5: Adversarial → balrog attacks the implementation (edge cases, error paths)
 Phase 4: Review     → /warden conventions + code quality + verification
 Phase 5: Complete   → PR creation + worktree cleanup
 ```

--- a/cli/cmd/fellowship/main.go
+++ b/cli/cmd/fellowship/main.go
@@ -807,12 +807,8 @@ func runInit(d *db.DB) int {
 	initDir := fs.String("dir", "", "Worktree or repo root (default: auto-detect via git)")
 	fs.Parse(os.Args[2:])
 
-	validPhases := map[string]bool{
-		"Onboard": true, "Research": true, "Plan": true,
-		"Implement": true, "Review": true, "Complete": true,
-	}
-	if *phase != "" && !validPhases[*phase] {
-		fmt.Fprintf(os.Stderr, "fellowship: invalid phase %q\n", *phase)
+	if *phase != "" && !state.IsValidPhase(*phase) {
+		fmt.Fprintf(os.Stderr, "fellowship: invalid phase %q (valid: %s)\n", *phase, strings.Join(state.Phases(), ", "))
 		return 1
 	}
 

--- a/cli/internal/company/company.go
+++ b/cli/internal/company/company.go
@@ -25,15 +25,15 @@ type CompanyProgress struct {
 	Pending    int    `json:"pending_gates"` // quests with gate_pending
 }
 
-// phaseRank maps phases to a numeric rank for progress tracking.
-var phaseRank = map[string]int{
-	"Onboard":   0,
-	"Research":  1,
-	"Plan":      2,
-	"Implement": 3,
-	"Review":    4,
-	"Complete":  5,
-}
+// phaseRank maps phases to a numeric rank for progress tracking,
+// derived from the canonical phase order in the state package.
+var phaseRank = func() map[string]int {
+	m := make(map[string]int)
+	for i, p := range state.Phases() {
+		m[p] = i
+	}
+	return m
+}()
 
 // CalculateProgress computes aggregate progress for a company given quest statuses.
 func CalculateProgress(company dashboard.CompanyEntry, quests []dashboard.QuestStatus) CompanyProgress {
@@ -55,7 +55,7 @@ func CalculateProgress(company dashboard.CompanyEntry, quests []dashboard.QuestS
 		if qs.Phase == "Complete" {
 			progress.Completed++
 		}
-		if rank, ok := phaseRank[qs.Phase]; ok && rank >= 3 { // Implement+
+		if rank, ok := phaseRank[qs.Phase]; ok && rank >= phaseRank["Implement"] {
 			progress.InProgress++
 		}
 		if qs.GatePending {

--- a/cli/internal/state/state.go
+++ b/cli/internal/state/state.go
@@ -45,6 +45,23 @@ func IsEarlyPhase(phase string) bool {
 	return phase == "Onboard" || phase == "Research" || phase == "Plan"
 }
 
+// Phases returns the ordered quest phase names.
+func Phases() []string {
+	out := make([]string, len(phaseOrder))
+	copy(out, phaseOrder)
+	return out
+}
+
+// IsValidPhase reports whether p is a known quest phase.
+func IsValidPhase(p string) bool {
+	for _, phase := range phaseOrder {
+		if phase == p {
+			return true
+		}
+	}
+	return false
+}
+
 // Load reads quest state from DB by quest name.
 func Load(conn *sqlite.Conn, questName string) (*State, error) {
 	var s State

--- a/cli/internal/state/state_test.go
+++ b/cli/internal/state/state_test.go
@@ -128,6 +128,19 @@ func TestNextPhase(t *testing.T) {
 	}
 }
 
+func TestIsValidPhase(t *testing.T) {
+	for _, p := range []string{"Onboard", "Research", "Plan", "Implement", "Adversarial", "Review", "Complete"} {
+		if !state.IsValidPhase(p) {
+			t.Errorf("IsValidPhase(%q) = false, want true", p)
+		}
+	}
+	for _, p := range []string{"", "onboard", "InvalidPhase", "Done"} {
+		if state.IsValidPhase(p) {
+			t.Errorf("IsValidPhase(%q) = true, want false", p)
+		}
+	}
+}
+
 func TestIsEarlyPhase(t *testing.T) {
 	early := []string{"Onboard", "Research", "Plan"}
 	late := []string{"Implement", "Adversarial", "Review", "Complete"}

--- a/plugin/CLAUDE.md
+++ b/plugin/CLAUDE.md
@@ -21,6 +21,16 @@ plugin/hooks/scripts/ensure-binary.sh # Downloads CLI binary from GitHub release
 - **Skills vs commands:** Skills are for things Claude needs to know about and invoke automatically (quest phases, context compression). Commands are for user-invoked actions that don't need to consume base context (guide, settings, scribe). If only the user types it, make it a command.
 - **Changelog** in README.md is append-only per version. Don't edit historical entries — they describe what shipped at that version.
 
+## Paired content (keep in sync)
+
+Cross-file duplication that exists on purpose — agent files must be self-contained at runtime (they're injected as system prompts with no path context), and docs mirror the canonical schema. When editing one side, update the other:
+
+- `plugin/agents/_protocol.md` (canonical) ↔ protocol blocks embedded in `plugin/agents/balrog.md`, `palantir.md`, `scout.md`
+- `plugin/skills/gather-lore/SKILL.md` Step 2 pattern taxonomy ↔ `plugin/skills/warden/SKILL.md` Step 3 dimensions (and gather-lore Step 4 ↔ warden Step 6)
+- Config schema: `plugin/commands/settings.md` (canonical) ↔ README Configuration section ↔ `site/src/routes/configuration/+page.svelte`
+
+Do not encode these as HTML comments inside skill/agent prompt files — hidden directives in agent-facing content can be followed by agents as instructions.
+
 ## Releasing
 
 1. Bump `version` in `.claude-plugin/plugin.json`

--- a/plugin/agents/_protocol.md
+++ b/plugin/agents/_protocol.md
@@ -17,10 +17,10 @@ Use `SendMessage` to deliver findings or status to the requesting agent:
 }
 ```
 
-- `recipient`: whoever requested the work, as provided at spawn time:
-  - Agents spawned by a teammate (e.g. balrog, spawned by a quest runner): the **requester task ID** from the spawn context.
+- `recipient`: whoever requested the work, as provided at spawn time. **SendMessage addresses agents by teammate name, not task ID.**
+  - Agents spawned by a teammate (e.g. balrog, spawned by a quest runner): the **requester's teammate name** from the spawn context (e.g. `"quest-auth-bug"`).
   - Agents spawned by the fellowship lead (e.g. palantir): the lead — `"team-lead"`.
-  - If no requester was provided (standalone mode), present output directly to the user instead of using SendMessage.
+  - If no requester name was provided (standalone mode), present output directly to the user instead of using SendMessage.
 - `content`: full markdown report body.
 - `summary`: one-line description shown in task logs (e.g., `"balrog: 2 critical, 1 high, 0 medium, 3 low findings"`).
 

--- a/plugin/agents/_protocol.md
+++ b/plugin/agents/_protocol.md
@@ -1,6 +1,8 @@
 # Fellowship Agent Messaging Protocol
 
-Shared protocol for all fellowship agents. Agents that communicate via `SendMessage` and respond to lifecycle events must follow this spec.
+Canonical spec for how fellowship agents deliver reports and respond to lifecycle events via `SendMessage`.
+
+> **Sync note:** Agent definition files must be self-contained at runtime — an installed plugin's agents cannot reliably read sibling files (their working directory is the user's project, not the plugin cache). Each agent therefore embeds the parts of this protocol it needs inline. When you edit this spec, update the embedded copies in `balrog.md`, `palantir.md`, and `scout.md`.
 
 ## Sending a Report
 
@@ -9,13 +11,16 @@ Use `SendMessage` to deliver findings or status to the requesting agent:
 ```json
 {
   "type": "message",
-  "recipient": "<requester_task_id>",
+  "recipient": "<requester>",
   "content": "[markdown content]",
   "summary": "[short one-line summary for logs]"
 }
 ```
 
-- `recipient`: the task ID provided at spawn time. If not provided (standalone mode), present output directly to the user instead.
+- `recipient`: whoever requested the work, as provided at spawn time:
+  - Agents spawned by a teammate (e.g. balrog, spawned by a quest runner): the **requester task ID** from the spawn context.
+  - Agents spawned by the fellowship lead (e.g. palantir): the lead — `"team-lead"`.
+  - If no requester was provided (standalone mode), present output directly to the user instead of using SendMessage.
 - `content`: full markdown report body.
 - `summary`: one-line description shown in task logs (e.g., `"balrog: 2 critical, 1 high, 0 medium, 3 low findings"`).
 

--- a/plugin/agents/_protocol.md
+++ b/plugin/agents/_protocol.md
@@ -2,7 +2,7 @@
 
 Canonical spec for how fellowship agents deliver reports and respond to lifecycle events via `SendMessage`.
 
-> **Sync note:** Agent definition files must be self-contained at runtime — an installed plugin's agents cannot reliably read sibling files (their working directory is the user's project, not the plugin cache). Each agent therefore embeds the parts of this protocol it needs inline. When you edit this spec, update the embedded copies in `balrog.md`, `palantir.md`, and `scout.md`.
+> **Sync note:** Agent definition files must be self-contained at runtime — an agent's markdown is injected as its system prompt with no path context, so an installed plugin's agents cannot reliably read sibling files (their working directory is the user's project, not the plugin cache). Skills are different: the Skill tool exposes the invoked skill's directory, which is why SKILL.md files can reference sibling `resources/*.md` while agents cannot. Each agent therefore embeds the parts of this protocol it needs inline. When you edit this spec, update the embedded copies in `balrog.md`, `palantir.md`, and `scout.md`.
 
 ## Sending a Report
 

--- a/plugin/agents/balrog.md
+++ b/plugin/agents/balrog.md
@@ -90,7 +90,17 @@ For each finding, include:
 
 ## Reporting
 
-When your analysis is complete, report findings using the fellowship messaging protocol defined in `plugin/agents/_protocol.md`. Read that file for the exact message shape.
+When your analysis is complete, report findings via `SendMessage`:
+
+<!-- Embedded from _protocol.md (Sending a Report) — keep in sync -->
+```json
+{
+  "type": "message",
+  "recipient": "<requester_task_id>",
+  "content": "[markdown report body]",
+  "summary": "balrog: N critical, N high, N medium, N low findings"
+}
+```
 
 Use the **Requester task ID** from your spawn context as the `recipient` value. If no requester task ID was provided (standalone mode), present findings directly to the user instead of using SendMessage.
 
@@ -111,7 +121,18 @@ If there are no findings, send a clear verdict — zero findings is a valid resu
 
 ## Shutdown and Lifecycle
 
-Follow the fellowship agent lifecycle protocol defined in `plugin/agents/_protocol.md`.
+<!-- Embedded from _protocol.md (Shutdown) — keep in sync -->
+When you receive a shutdown request via `SendMessage`, respond immediately and stop:
+
+```json
+{
+  "type": "shutdown_response",
+  "request_id": "<from the incoming message>",
+  "approve": true
+}
+```
+
+Do not perform any further work after sending a shutdown response.
 
 ## Key Principles
 

--- a/plugin/agents/balrog.md
+++ b/plugin/agents/balrog.md
@@ -13,7 +13,7 @@ You are balrog — an adversarial validation agent. Your job is to find every wa
 Quest spawns you with:
 - **Worktree path**: where the implementation lives
 - **Task description**: what was built
-- **Requester task ID**: the quest runner's task ID (for reporting back)
+- **Requester name**: the quest teammate's name, for reporting back — SendMessage addresses agents by name, not task ID
 
 If the worktree path is provided, run `git -C <worktree_path> diff refs/remotes/origin/HEAD...HEAD` to get the full diff of everything implemented. If that ref is unavailable (the command fails), fall back to `git -C <worktree_path> rev-parse --abbrev-ref origin/HEAD`, strip the `origin/` prefix, and diff against that branch name. If no worktree path is given, do the same from the current directory using the current directory in place of `-C <worktree_path>`.
 
@@ -94,17 +94,16 @@ For each finding, include:
 
 When your analysis is complete, report findings via `SendMessage`:
 
-<!-- Embedded from _protocol.md (Sending a Report) — keep in sync -->
 ```json
 {
   "type": "message",
-  "recipient": "<requester_task_id>",
+  "recipient": "<requester_name>",
   "content": "[markdown report body]",
   "summary": "balrog: N critical, N high, N medium, N low findings"
 }
 ```
 
-Use the **Requester task ID** from your spawn context as the `recipient` value. If no requester task ID was provided (standalone mode), present findings directly to the user instead of using SendMessage.
+Use the **Requester name** from your spawn context as the `recipient` value. If no requester name was provided (standalone mode), present findings directly to the user instead of using SendMessage.
 
 The content should follow this structure:
 ```
@@ -123,7 +122,6 @@ If there are no findings, send a clear verdict — zero findings is a valid resu
 
 ## Shutdown and Lifecycle
 
-<!-- Embedded from _protocol.md (Shutdown) — keep in sync -->
 When you receive a shutdown request via `SendMessage`, respond immediately and stop:
 
 ```json

--- a/plugin/agents/balrog.md
+++ b/plugin/agents/balrog.md
@@ -1,7 +1,7 @@
 ---
 name: balrog
 description: Adversarial validation agent. Spawned by quest between Implement and Review phases. Analyzes the quest diff for failure modes, writes targeted test cases, runs them, and delivers a severity-ranked findings report. Critical/High findings must be addressed before the Review gate opens.
-tools: Read, Grep, Glob, Bash, SendMessage
+tools: Read, Grep, Glob, Write, Edit, Bash, SendMessage
 ---
 
 You are balrog — an adversarial validation agent. Your job is to find every way the code can fail before it reaches review. You think like an attacker, not a reviewer.

--- a/plugin/agents/balrog.md
+++ b/plugin/agents/balrog.md
@@ -6,6 +6,8 @@ tools: Read, Grep, Glob, Write, Edit, Bash, SendMessage
 
 You are balrog — an adversarial validation agent. Your job is to find every way the code can fail before it reaches review. You think like an attacker, not a reviewer.
 
+**Write boundary:** Your Write and Edit tools are for test files you author — nothing else. Never modify production or source files, even to fix a CRITICAL finding you are certain about. Your report's `Fix` field tells the quest runner what to change; the quest runner applies fixes and confirms them against your reproduction steps. Remove temporary test files before reporting (keep only tests intentionally left as regression coverage, and list them).
+
 ## Your Context
 
 Quest spawns you with:
@@ -137,6 +139,7 @@ Do not perform any further work after sending a shutdown response.
 ## Key Principles
 
 - **Think like an attacker.** Your job is to break the code, not to validate that it works. Assume the implementation is wrong until proven otherwise.
+- **Report, don't repair.** You find and prove failures; the quest runner fixes them. Touching source files yourself produces unattributed, ungated edits in the quest's PR.
 - **Test, don't speculate.** Write and run actual tests wherever possible. Findings backed by test output carry more weight than code reading alone.
 - **Scope to the diff.** Analyze what changed in this quest. Don't audit the entire codebase.
 - **Be specific.** A finding without a reproduction path is noise. Every finding needs a location, an attack, and evidence.

--- a/plugin/agents/palantir.md
+++ b/plugin/agents/palantir.md
@@ -79,6 +79,7 @@ Use `fellowship bulletin list --json` to read all entries.
 
 When you detect an issue, send a message to the lead using `SendMessage`:
 
+<!-- Embedded from _protocol.md (Sending a Report) — keep in sync. Palantir is lead-spawned, so the recipient is "team-lead". -->
 ```json
 {
   "type": "message",
@@ -131,15 +132,18 @@ Where `<type>` is one of: `stuck`, `drift`, `conflict`, `health`, `bulletin`. Ap
 
 ### 7. Respond to Shutdown
 
-When you receive a shutdown request from the lead, respond immediately:
+When you receive a shutdown request from the lead, respond immediately and stop:
 
+<!-- Embedded from _protocol.md (Shutdown) — keep in sync -->
 ```json
 {
   "type": "shutdown_response",
-  "request_id": "{from the message}",
+  "request_id": "<from the incoming message>",
   "approve": true
 }
 ```
+
+Do not perform any further work after sending a shutdown response.
 
 ## Key Principles
 

--- a/plugin/agents/palantir.md
+++ b/plugin/agents/palantir.md
@@ -79,7 +79,6 @@ Use `fellowship bulletin list --json` to read all entries.
 
 When you detect an issue, send a message to the lead using `SendMessage`:
 
-<!-- Embedded from _protocol.md (Sending a Report) — keep in sync. Palantir is lead-spawned, so the recipient is "team-lead". -->
 ```json
 {
   "type": "message",
@@ -134,7 +133,6 @@ Where `<type>` is one of: `stuck`, `drift`, `conflict`, `health`, `bulletin`. Ap
 
 When you receive a shutdown request from the lead, respond immediately and stop:
 
-<!-- Embedded from _protocol.md (Shutdown) — keep in sync -->
 ```json
 {
   "type": "shutdown_response",

--- a/plugin/agents/palantir.md
+++ b/plugin/agents/palantir.md
@@ -2,6 +2,7 @@
 name: palantir
 description: Background monitor during fellowship execution. Watches quest progress via task metadata, detects stuck quests, scope drift, and file conflicts. Spawned by Gandalf alongside quest teammates. Reports issues to the lead via SendMessage.
 tools: TaskList, TaskGet, SendMessage, Read, Grep, Glob, Bash
+model: haiku
 ---
 
 You are a palantir agent — a background monitor that watches over active quests during a fellowship. You observe quest progress, detect problems early, and alert the lead (Gandalf) before issues compound.

--- a/plugin/agents/palantir.md
+++ b/plugin/agents/palantir.md
@@ -34,7 +34,7 @@ Between checks, you go idle. This is normal — don't try to self-wake or loop.
 
 Check task metadata for phase updates:
 - Use `TaskList` to read all tasks and their metadata
-- Each quest teammate updates their task's `phase` metadata field at phase transitions (Onboard, Research, Plan, Implement, Review, Complete)
+- Each quest teammate updates their task's `phase` metadata field at phase transitions (Onboard, Research, Plan, Implement, Adversarial, Review, Complete). Adversarial means the quest is waiting on a balrog review run — a legitimately slow phase; don't flag it as stuck prematurely.
 - If a quest's phase hasn't changed after a prolonged period, flag it as potentially stuck
 
 **What "stuck" looks like:**

--- a/plugin/agents/scout.md
+++ b/plugin/agents/scout.md
@@ -2,6 +2,7 @@
 name: scout
 description: Research & analysis agent. Investigates questions and analyzes codebases without modifying source code. Can write research notes to docs/research/ or .fellowship/. No git operations, no commits, no PRs.
 tools: Read, Glob, Grep, Agent, Skill, TaskUpdate, SendMessage, Write
+model: sonnet
 ---
 
 You are a scout — an autonomous research agent that investigates questions and delivers structured findings.

--- a/plugin/agents/scout.md
+++ b/plugin/agents/scout.md
@@ -27,4 +27,15 @@ When running as a fellowship teammate (indicated by your spawn prompt):
    - `TaskUpdate(taskId: "<task_id>", metadata: {"phase": "Done"})` before delivery
 2. Send your final report to the lead via `SendMessage`
 3. If you get stuck or need a decision, message the lead
-4. If you receive a shutdown request, respond immediately using `SendMessage` with type "shutdown_response", approve: true, and the request_id from the message
+4. If you receive a shutdown request, respond immediately and stop:
+
+   <!-- Embedded from _protocol.md (Shutdown) — keep in sync -->
+   ```json
+   {
+     "type": "shutdown_response",
+     "request_id": "<from the incoming message>",
+     "approve": true
+   }
+   ```
+
+   Do not perform any further work after sending a shutdown response.

--- a/plugin/agents/scout.md
+++ b/plugin/agents/scout.md
@@ -25,7 +25,19 @@ When running as a fellowship teammate (indicated by your spawn prompt):
    - `TaskUpdate(taskId: "<task_id>", metadata: {"phase": "Investigating"})` at start
    - `TaskUpdate(taskId: "<task_id>", metadata: {"phase": "Validating"})` if validating
    - `TaskUpdate(taskId: "<task_id>", metadata: {"phase": "Done"})` before delivery
-2. Send your final report to the lead via `SendMessage`
+2. Send your final report to the lead via `SendMessage` using this envelope:
+
+   <!-- Embedded from _protocol.md (Sending a Report) — keep in sync. Scout is lead-spawned, so the recipient is "team-lead". -->
+   ```json
+   {
+     "type": "message",
+     "recipient": "team-lead",
+     "content": "[full markdown scout report]",
+     "summary": "scout: [one-line finding summary]"
+   }
+   ```
+
+   If you were spawned standalone (no fellowship team in your spawn prompt), present the report directly to the user instead.
 3. If you get stuck or need a decision, message the lead
 4. If you receive a shutdown request, respond immediately and stop:
 

--- a/plugin/agents/scout.md
+++ b/plugin/agents/scout.md
@@ -27,7 +27,6 @@ When running as a fellowship teammate (indicated by your spawn prompt):
    - `TaskUpdate(taskId: "<task_id>", metadata: {"phase": "Done"})` before delivery
 2. Send your final report to the lead via `SendMessage` using this envelope:
 
-   <!-- Embedded from _protocol.md (Sending a Report) — keep in sync. Scout is lead-spawned, so the recipient is "team-lead". -->
    ```json
    {
      "type": "message",
@@ -41,7 +40,6 @@ When running as a fellowship teammate (indicated by your spawn prompt):
 3. If you get stuck or need a decision, message the lead
 4. If you receive a shutdown request, respond immediately and stop:
 
-   <!-- Embedded from _protocol.md (Shutdown) — keep in sync -->
    ```json
    {
      "type": "shutdown_response",

--- a/plugin/agents/validator.md
+++ b/plugin/agents/validator.md
@@ -1,0 +1,26 @@
+---
+name: validator
+description: Read-only adversarial validator. Spawned by scout to verify research findings against the actual code. Challenges assumptions, confirms or refutes claims, and reports CONFIRMED/CONTESTED/UNVERIFIED. Cannot modify files or run commands — enforced by tool restrictions.
+tools: Read, Glob, Grep
+model: sonnet
+---
+
+You are a research validator. Your job is adversarial: challenge assumptions, verify factual claims, and flag anything wrong or unsupported. Your value is in catching errors, not agreeing.
+
+Your spawn prompt contains the findings to validate, including file paths and line references.
+
+## Procedure
+
+1. For each factual claim, read the referenced file and line range. Does the code actually do what the finding says?
+2. For each Medium/Low confidence finding, investigate independently. Can you confirm or refute it?
+3. Produce a validation report:
+   - **CONFIRMED**: claims you verified are correct
+   - **CONTESTED**: claims that are wrong or misleading, with evidence (file:line)
+   - **UNVERIFIED**: claims you couldn't confirm or deny, and why
+
+## Boundaries
+
+- Read any file. Your tools cannot modify files or run commands — this is enforced by your tool restrictions, not advisory.
+- Be adversarial. A validation pass that only agrees adds nothing.
+
+Your final response text is the validation report delivered back to the scout that spawned you.

--- a/plugin/commands/guide.md
+++ b/plugin/commands/guide.md
@@ -38,7 +38,7 @@ Wait for their response. This is the task description used for the rest of the g
 
 **Goal:** Understand the relevant parts of the codebase before making a plan.
 
-1. Use the Explore agent (Agent tool with subagent_type=Explore) to find files related to the task. Focus on:
+1. Use the Explore agent (Agent tool with subagent_type=Explore, passing `model: "haiku"` — or `models.explore` from fellowship config if set) to find files related to the task. Focus on:
    - Files that will likely need modification
    - Files that define patterns to follow
    - Test files for the affected area

--- a/plugin/commands/settings.md
+++ b/plugin/commands/settings.md
@@ -94,7 +94,7 @@ This is the canonical schema for fellowship config files. Both `~/.claude/fellow
 | `models.palantir` | string \| null | `null` | Model for the palantir monitor. Same valid values. `null` = built-in default: `haiku` (from the palantir agent definition). |
 | `models.balrog` | string \| null | `null` | Model for balrog adversarial review. Same valid values. `null` = built-in default: inherit the session model. |
 | `models.explore` | string \| null | `null` | Model for Explore scan subagents spawned by quest, scout, council, and guide. Same valid values. `null` = built-in default: `haiku`. |
-| `models.validator` | string \| null | `null` | Model for scout's validation subagent. Same valid values. `null` = built-in default: `sonnet`. |
+| `models.validator` | string \| null | `null` | Model for scout's validation subagent. Same valid values. `null` = built-in default: `sonnet` (from the validator agent definition). |
 
 ## Merge Semantics
 

--- a/plugin/commands/settings.md
+++ b/plugin/commands/settings.md
@@ -36,6 +36,12 @@ Fellowship Config
   palantir.enabled       true                     [default]
   palantir.minQuests     2                        [default]
   issues.autoClose       true                     [default]
+  models.quest           null (inherit)           [default]
+  models.scout           null (sonnet)            [default]
+  models.palantir        null (haiku)             [default]
+  models.balrog          null (inherit)           [default]
+  models.explore         null (haiku)             [default]
+  models.validator       null (sonnet)            [default]
 
   User config:    ~/.claude/fellowship.json
   Project config: .fellowship/config.json (none found)
@@ -83,6 +89,12 @@ This is the canonical schema for fellowship config files. Both `~/.claude/fellow
 | `palantir.enabled` | boolean | `true` | `true`, `false` |
 | `palantir.minQuests` | number | `2` | Any positive integer |
 | `issues.autoClose` | boolean | `true` | `true`, `false`. When true, `/missive` includes `Closes #N` in PR keywords. |
+| `models.quest` | string \| null | `null` | Model for quest teammates. A model alias (`haiku`, `sonnet`, `opus`), a full model ID, or `"inherit"`. `null` = built-in default: inherit the session model. |
+| `models.scout` | string \| null | `null` | Model for scout teammates. Same valid values. `null` = built-in default: `sonnet` (from the scout agent definition). |
+| `models.palantir` | string \| null | `null` | Model for the palantir monitor. Same valid values. `null` = built-in default: `haiku` (from the palantir agent definition). |
+| `models.balrog` | string \| null | `null` | Model for balrog adversarial review. Same valid values. `null` = built-in default: inherit the session model. |
+| `models.explore` | string \| null | `null` | Model for Explore scan subagents spawned by quest, scout, and council. Same valid values. `null` = built-in default: `haiku`. |
+| `models.validator` | string \| null | `null` | Model for scout's validation subagent. Same valid values. `null` = built-in default: `sonnet`. |
 
 ## Merge Semantics
 

--- a/plugin/commands/settings.md
+++ b/plugin/commands/settings.md
@@ -83,17 +83,17 @@ This is the canonical schema for fellowship config files. Both `~/.claude/fellow
 | `branch.ticketPattern` | string | `"[A-Z]+-\\d+"` | Any valid regex |
 | `worktree.enabled` | boolean | `true` | `true`, `false` |
 | `worktree.directory` | string \| null | `null` | Absolute path to a directory |
-| `gates.autoApprove` | string[] | `[]` | `"Research"`, `"Plan"`, `"Implement"`, `"Review"`, `"Complete"`. Names refer to the completed phase — e.g., `"Research"` auto-approves the Research→Plan transition. |
+| `gates.autoApprove` | string[] | `[]` | `"Onboard"`, `"Research"`, `"Plan"`, `"Implement"`, `"Adversarial"`, `"Review"`. Names refer to the phase being left — e.g., `"Research"` auto-approves the Research→Plan transition. `"Complete"` is not a valid value (no transition leaves Complete). |
 | `pr.draft` | boolean | `false` | `true`, `false` |
 | `pr.template` | string \| null | `null` | Template with `{task}`, `{summary}`, `{changes}` placeholders |
 | `palantir.enabled` | boolean | `true` | `true`, `false` |
 | `palantir.minQuests` | number | `2` | Any positive integer |
 | `issues.autoClose` | boolean | `true` | `true`, `false`. When true, `/missive` includes `Closes #N` in PR keywords. |
-| `models.quest` | string \| null | `null` | Model for quest teammates. A model alias (`haiku`, `sonnet`, `opus`), a full model ID, or `"inherit"`. `null` = built-in default: inherit the session model. |
+| `models.quest` | string \| null | `null` | Model for quest teammates. Valid values: the aliases `"haiku"`, `"sonnet"`, `"opus"` — these are passed verbatim as the Agent tool's `model` parameter, which does not accept `"inherit"` or full model IDs. To inherit the session model, leave the key `null` (the parameter is then omitted). `null` = built-in default: inherit the session model. |
 | `models.scout` | string \| null | `null` | Model for scout teammates. Same valid values. `null` = built-in default: `sonnet` (from the scout agent definition). |
 | `models.palantir` | string \| null | `null` | Model for the palantir monitor. Same valid values. `null` = built-in default: `haiku` (from the palantir agent definition). |
 | `models.balrog` | string \| null | `null` | Model for balrog adversarial review. Same valid values. `null` = built-in default: inherit the session model. |
-| `models.explore` | string \| null | `null` | Model for Explore scan subagents spawned by quest, scout, and council. Same valid values. `null` = built-in default: `haiku`. |
+| `models.explore` | string \| null | `null` | Model for Explore scan subagents spawned by quest, scout, council, and guide. Same valid values. `null` = built-in default: `haiku`. |
 | `models.validator` | string \| null | `null` | Model for scout's validation subagent. Same valid values. `null` = built-in default: `sonnet`. |
 
 ## Merge Semantics

--- a/plugin/skills/council/SKILL.md
+++ b/plugin/skills/council/SKILL.md
@@ -63,7 +63,7 @@ This scope constrains all downstream scanning and verification.
 
 ### Step 4: Scan for Relevant Files
 
-Use the Explore agent (Task tool with subagent_type=Explore) to find files related to the task description. **In a monorepo, scope the search to the identified package(s)** — do not scan the entire repo.
+Use the Explore agent (Agent tool with subagent_type=Explore) to find files related to the task description. **In a monorepo, scope the search to the identified package(s)** — do not scan the entire repo.
 
 Focus on:
 - Files that will likely need modification
@@ -112,4 +112,4 @@ Revise based on feedback.
 
 - **Targeted, not exhaustive.** 5-10 key files, not every file in the directory.
 - **Carry forward.** The Session Context block is referenced by lembas and quest throughout the session.
-- **One question.** Don't interrogate the user. One focused question, then do the work.
+- **Minimal questions.** One focused task question (Step 2); ambiguous monorepo scope (Step 3) and final confirmation (Step 6) may each add one more. Don't interrogate beyond that.

--- a/plugin/skills/council/SKILL.md
+++ b/plugin/skills/council/SKILL.md
@@ -112,4 +112,4 @@ Revise based on feedback.
 
 - **Targeted, not exhaustive.** 5-10 key files, not every file in the directory.
 - **Carry forward.** The Session Context block is referenced by lembas and quest throughout the session.
-- **Minimal questions.** One focused task question (Step 2); ambiguous monorepo scope (Step 3) and final confirmation (Step 6) may each add one more. Don't interrogate beyond that.
+- **Minimal questions, never stall.** One focused task question (Step 2) when the task wasn't already provided; Steps 0, 3, and 6 ask only when genuinely ambiguous. As a fellowship teammate there is no direct user — route blocking questions to the lead via SendMessage, and otherwise proceed with documented assumptions rather than waiting on confirmation.

--- a/plugin/skills/council/SKILL.md
+++ b/plugin/skills/council/SKILL.md
@@ -63,7 +63,7 @@ This scope constrains all downstream scanning and verification.
 
 ### Step 4: Scan for Relevant Files
 
-Use the Explore agent (Agent tool with subagent_type=Explore) to find files related to the task description. **In a monorepo, scope the search to the identified package(s)** — do not scan the entire repo.
+Use the Explore agent (Agent tool with subagent_type=Explore, passing `model: "haiku"` — file scanning does not need the session model; use `models.explore` from fellowship config instead if set) to find files related to the task description. **In a monorepo, scope the search to the identified package(s)** — do not scan the entire repo.
 
 Focus on:
 - Files that will likely need modification

--- a/plugin/skills/fellowship/SKILL.md
+++ b/plugin/skills/fellowship/SKILL.md
@@ -65,7 +65,7 @@ Do not proceed with any other startup steps.
 
 ### Load Config
 
-At startup, read `~/.claude/fellowship.json` (the user's personal Claude directory) if it exists. Merge with defaults — any key not present uses the default value. If the file does not exist, all defaults apply.
+At startup, read both config layers (neither is required to exist): the project config at `.fellowship/config.json` (repo root) and the user config at `~/.claude/fellowship.json` (the user's personal Claude directory). Merge as **defaults → project → user** (user always wins; see `/settings` for the merge semantics). Any key present in neither file uses the default value.
 
 **Config keys used by fellowship:** `branch.*` (branch naming), `worktree.*` (isolation), `gates.autoApprove` (gate routing), `pr.*` (PR creation), `palantir.*` (monitoring), `models.*` (model routing for spawned agents). See `/settings` for the full schema, defaults, and valid values.
 
@@ -199,6 +199,10 @@ If no issue references are found, `{issue_context}` is substituted with an empty
      worktree exists (`git worktree list`) and that its path is not the main root.
      Never tell a teammate it is "already isolated" unless you have verified its
      worktree exists.
+   - **Publish the verified path BEFORE spawning:** run
+     `TaskUpdate(taskId: "<task_id>", metadata: {"worktree_path": "<path>"})` so
+     quest Phase 0's `TaskGet` check finds the provisioned worktree and skips
+     creating a second one on the wrong branch.
    - **Two safeguards catch the bug regardless of how isolation was provisioned:**
      (1) the teammate's mandatory isolation SELF-CHECK before its first write —
      top-level must differ from the main root, else STOP and message the lead

--- a/plugin/skills/fellowship/SKILL.md
+++ b/plugin/skills/fellowship/SKILL.md
@@ -67,7 +67,9 @@ Do not proceed with any other startup steps.
 
 At startup, read `~/.claude/fellowship.json` (the user's personal Claude directory) if it exists. Merge with defaults — any key not present uses the default value. If the file does not exist, all defaults apply.
 
-**Config keys used by fellowship:** `branch.*` (branch naming), `worktree.*` (isolation), `gates.autoApprove` (gate routing), `pr.*` (PR creation), `palantir.*` (monitoring). See `/settings` for the full schema, defaults, and valid values.
+**Config keys used by fellowship:** `branch.*` (branch naming), `worktree.*` (isolation), `gates.autoApprove` (gate routing), `pr.*` (PR creation), `palantir.*` (monitoring), `models.*` (model routing for spawned agents). See `/settings` for the full schema, defaults, and valid values.
+
+**Model routing:** When spawning any teammate or agent below, check `config.models.<role>` (`quest`, `scout`, `palantir`). If set, pass its value as the Agent tool's `model` parameter for that spawn. If unset, omit the parameter — the agent definition's own default applies (scout: sonnet, palantir: haiku) and quest teammates inherit the session model. A per-invocation `model` parameter overrides the agent definition's frontmatter, so config always wins when present.
 
 **IMPORTANT — gate defaults:** When no config file exists, or when `gates.autoApprove` is absent/empty, ALL gates surface to the user. No gates are auto-approved by default. Gandalf must NEVER tell teammates that any gates are auto-approved unless `config.gates.autoApprove` explicitly lists them.
 
@@ -176,6 +178,7 @@ If no issue references are found, `{issue_context}` is substituted with an empty
    - `team_name`: the fellowship team name
    - `subagent_type: "general-purpose"`
    - `name`: `"quest-{n}"` or a descriptive name like `"quest-auth-bug"`
+   - `model`: `config.models.quest` if set; otherwise omit — quest teammates write production code and inherit the session model by default
    - **Isolation is the LEAD's job to PROVISION and VERIFY — never a flag to
      trust.** The Agent tool's `isolation: "worktree"` param has been observed to
      silently no-op for background quest teammates (no worktree is created; the
@@ -238,13 +241,13 @@ When uncertain, ask the user.
 For each scout, Gandalf:
 
 1. `TaskCreate` with the question and type "scout"
-2. Spawn via `Agent` tool with `subagent_type: "fellowship:scout"`, no worktree isolation.
+2. Spawn via `Agent` tool with `subagent_type: "fellowship:scout"`, no worktree isolation. Pass `model: config.models.scout` if set; otherwise omit (the scout agent definition defaults to sonnet).
 
 **Spawn prompt:** See [resources/spawn-prompts.md](resources/spawn-prompts.md) for the scout spawn prompt template.
 
 ### Spawn Palantir
 
-When `config.palantir.minQuests` or more quests are active (default: 2) and `config.palantir.enabled` is true (default), spawn a palantir monitoring agent. Only one palantir per fellowship. Shut down when quests drop below threshold.
+When `config.palantir.minQuests` or more quests are active (default: 2) and `config.palantir.enabled` is true (default), spawn a palantir monitoring agent. Only one palantir per fellowship. Shut down when quests drop below threshold. Pass `model: config.models.palantir` if set; otherwise omit (the palantir agent definition defaults to haiku — monitoring is read-only status checking).
 
 **Spawn prompt:** See [resources/spawn-prompts.md](resources/spawn-prompts.md) for the palantir spawn prompt template.
 

--- a/plugin/skills/fellowship/SKILL.md
+++ b/plugin/skills/fellowship/SKILL.md
@@ -218,7 +218,7 @@ When the user's prompt references a plan file (e.g., "implement docs/plans/my-pl
 
 1. Validate the plan file exists — read it to confirm
 2. `TaskCreate` with the task description including the plan reference
-3. Spawn a teammate using the **Plan-Driven Quest Spawn Prompt** from spawn-prompts.md
+3. Spawn a teammate using the quest spawn prompt's **Plan-Driven variant** from spawn-prompts.md
 4. After spawning, add the quest to fellowship state as normal
 
 **Fan-out mode (multiple quests from one plan):**

--- a/plugin/skills/fellowship/SKILL.md
+++ b/plugin/skills/fellowship/SKILL.md
@@ -172,12 +172,12 @@ For each quest, Gandalf:
 
 If no issue references are found, `{issue_context}` is substituted with an empty string.
 
-2. Spawn a teammate via the `Task` tool with:
+2. Spawn a teammate via the `Agent` tool with:
    - `team_name`: the fellowship team name
    - `subagent_type: "general-purpose"`
    - `name`: `"quest-{n}"` or a descriptive name like `"quest-auth-bug"`
    - **Isolation is the LEAD's job to PROVISION and VERIFY — never a flag to
-     trust.** The `Task`/Agent `isolation: "worktree"` param has been observed to
+     trust.** The Agent tool's `isolation: "worktree"` param has been observed to
      silently no-op for background quest teammates (no worktree is created; the
      teammate lands in the main repo root). Do NOT assume it worked, and do NOT
      rely on the teammate creating its own worktree in quest Phase 0 — that is
@@ -238,7 +238,7 @@ When uncertain, ask the user.
 For each scout, Gandalf:
 
 1. `TaskCreate` with the question and type "scout"
-2. Spawn via `Task` tool with `subagent_type: "fellowship:scout"`, no worktree isolation.
+2. Spawn via `Agent` tool with `subagent_type: "fellowship:scout"`, no worktree isolation.
 
 **Spawn prompt:** See [resources/spawn-prompts.md](resources/spawn-prompts.md) for the scout spawn prompt template.
 

--- a/plugin/skills/fellowship/SKILL.md
+++ b/plugin/skills/fellowship/SKILL.md
@@ -69,7 +69,7 @@ At startup, read `~/.claude/fellowship.json` (the user's personal Claude directo
 
 **Config keys used by fellowship:** `branch.*` (branch naming), `worktree.*` (isolation), `gates.autoApprove` (gate routing), `pr.*` (PR creation), `palantir.*` (monitoring), `models.*` (model routing for spawned agents). See `/settings` for the full schema, defaults, and valid values.
 
-**Model routing:** When spawning any teammate or agent below, check `config.models.<role>` (`quest`, `scout`, `palantir`). If set, pass its value as the Agent tool's `model` parameter for that spawn. If unset, omit the parameter — the agent definition's own default applies (scout: sonnet, palantir: haiku) and quest teammates inherit the session model. A per-invocation `model` parameter overrides the agent definition's frontmatter, so config always wins when present.
+**Model routing:** When spawning any teammate or agent below, check `config.models.<role>` (`quest`, `scout`, `palantir`). If set to a model alias (`haiku`, `sonnet`, `opus`), pass it as the Agent tool's `model` parameter for that spawn. If unset, `null`, or `"inherit"`, omit the parameter — the Agent tool's `model` parameter does not accept `"inherit"` or full model IDs; omission is how inheritance is spelled. With the parameter omitted, the agent definition's own default applies (scout: sonnet, palantir: haiku) and quest teammates inherit the session model. A per-invocation `model` parameter overrides the agent definition's frontmatter, so config always wins when present.
 
 **IMPORTANT — gate defaults:** When no config file exists, or when `gates.autoApprove` is absent/empty, ALL gates surface to the user. No gates are auto-approved by default. Gandalf must NEVER tell teammates that any gates are auto-approved unless `config.gates.autoApprove` explicitly lists them.
 
@@ -267,7 +267,7 @@ Each quest runs the full `/quest` lifecycle (6 phases with gates). Gates are enf
 
 **DEFAULT: ALL gates surface to the user.** No gates are ever auto-approved unless `config.gates.autoApprove` explicitly lists them. Gandalf must NEVER auto-approve a gate that is not listed in `config.gates.autoApprove`.
 
-**With `config.gates.autoApprove` (opt-in only):** Gates listed in the array are auto-approved by hooks. Valid gate names: `"Onboard"`, `"Research"`, `"Plan"`, `"Implement"`, `"Review"` (the phase being left).
+**With `config.gates.autoApprove` (opt-in only):** Gates listed in the array are auto-approved by hooks. Valid gate names: `"Onboard"`, `"Research"`, `"Plan"`, `"Implement"`, `"Adversarial"`, `"Review"` (the phase being left).
 
 ### Gate Approval Procedure
 

--- a/plugin/skills/fellowship/resources/lead-behavior.md
+++ b/plugin/skills/fellowship/resources/lead-behavior.md
@@ -7,10 +7,12 @@ digraph gandalf {
     "From user?" [shape=diamond];
     "Gate message?" [shape=diamond];
     "Quest completed?" [shape=diamond];
+    "All 5 gates + phase Complete?" [shape=diamond];
     "Quest stuck?" [shape=diamond];
     "Surface gate to user, WAIT" [shape=box];
     "Relay user decision to teammate" [shape=box];
     "Record PR URL, mark done, report" [shape=box];
+    "Reject completion, demand missing gates" [shape=box];
     "Report error, offer respawn" [shape=box];
     "No action (idle is normal)" [shape=box];
     "quest: {desc}?" [shape=diamond];
@@ -31,7 +33,9 @@ digraph gandalf {
     "Gate message?" -> "Surface gate to user, WAIT" [label="yes"];
     "Surface gate to user, WAIT" -> "Relay user decision to teammate";
     "Gate message?" -> "Quest completed?" [label="no"];
-    "Quest completed?" -> "Record PR URL, mark done, report" [label="yes"];
+    "Quest completed?" -> "All 5 gates + phase Complete?" [label="yes"];
+    "All 5 gates + phase Complete?" -> "Record PR URL, mark done, report" [label="yes"];
+    "All 5 gates + phase Complete?" -> "Reject completion, demand missing gates" [label="no"];
     "Quest completed?" -> "Quest stuck?" [label="no"];
     "Quest stuck?" -> "Report error, offer respawn" [label="yes"];
     "Quest stuck?" -> "No action (idle is normal)" [label="no"];

--- a/plugin/skills/fellowship/resources/lead-behavior.md
+++ b/plugin/skills/fellowship/resources/lead-behavior.md
@@ -7,7 +7,7 @@ digraph gandalf {
     "From user?" [shape=diamond];
     "Gate message?" [shape=diamond];
     "Quest completed?" [shape=diamond];
-    "All 5 gates + phase Complete?" [shape=diamond];
+    "All expected gates + phase Complete?" [shape=diamond];
     "Quest stuck?" [shape=diamond];
     "Surface gate to user, WAIT" [shape=box];
     "Relay user decision to teammate" [shape=box];
@@ -33,9 +33,9 @@ digraph gandalf {
     "Gate message?" -> "Surface gate to user, WAIT" [label="yes"];
     "Surface gate to user, WAIT" -> "Relay user decision to teammate";
     "Gate message?" -> "Quest completed?" [label="no"];
-    "Quest completed?" -> "All 5 gates + phase Complete?" [label="yes"];
-    "All 5 gates + phase Complete?" -> "Record PR URL, mark done, report" [label="yes"];
-    "All 5 gates + phase Complete?" -> "Reject completion, demand missing gates" [label="no"];
+    "Quest completed?" -> "All expected gates + phase Complete?" [label="yes"];
+    "All expected gates + phase Complete?" -> "Record PR URL, mark done, report" [label="yes"];
+    "All expected gates + phase Complete?" -> "Reject completion, demand missing gates" [label="no"];
     "Quest completed?" -> "Quest stuck?" [label="no"];
     "Quest stuck?" -> "Report error, offer respawn" [label="yes"];
     "Quest stuck?" -> "No action (idle is normal)" [label="no"];
@@ -73,14 +73,19 @@ digraph gandalf {
 
 ## Gate Tracking
 
-Gandalf maintains a gate count per teammate. A full quest has 5 gate transitions: Onboard→Research, Research→Plan, Plan→Implement, Implement→Review, Review→Complete. Each gate received (whether auto-approved or user-approved) increments the count.
+Gandalf maintains a gate count per teammate. The expected count depends on the quest's mode:
+
+- **Standard and promoted quests** have 6 gate transitions: Onboard→Research, Research→Plan, Plan→Implement, Implement→Adversarial, Adversarial→Review, Review→Complete.
+- **Plan-driven quests** start at Implement (Onboard/Research/Plan are recorded as skipped) and have 3: Implement→Adversarial, Adversarial→Review, Review→Complete.
+
+Each gate received (whether auto-approved or user-approved) increments the count.
 
 **Before accepting quest completion**, Gandalf verifies:
-1. The teammate's gate count equals 5 (all transitions completed)
+1. The teammate's gate count equals the expected count for its mode (6 standard/promoted, 3 plan-driven)
 2. The teammate's phase metadata shows "Complete"
 
 If either check fails, Gandalf rejects the completion:
-- Message the teammate: "Gate discipline violation — you have completed {N}/5 gates. You must submit gates for all phase transitions before completing. Missing: {list of missing transitions}."
+- Message the teammate: "Gate discipline violation — you have completed {N}/{expected} gates. You must submit gates for all phase transitions before completing. Missing: {list of missing transitions}."
 - Do NOT mark the task as done
 - Do NOT record a PR URL
 - Report the violation to the user

--- a/plugin/skills/fellowship/resources/lead-behavior.md
+++ b/plugin/skills/fellowship/resources/lead-behavior.md
@@ -113,7 +113,7 @@ When the user explicitly requests promotion (e.g., "promote scout-auth findings 
 5. **Spawn promoted quest:**
    - `TaskCreate` with the quest description
    - Read the findings file content
-   - Spawn a teammate using the **Promoted Quest Spawn Prompt** from spawn-prompts.md, with `{scout_findings_content}` set to the full file content
+   - Spawn a teammate using the quest spawn prompt's **Promoted variant** from spawn-prompts.md, with `{scout_findings_content}` set to the full file content
    - Add to state file via `fellowship state add-quest`
 6. **Report:** Tell the user the promotion is underway
 

--- a/plugin/skills/fellowship/resources/progress-tracking.md
+++ b/plugin/skills/fellowship/resources/progress-tracking.md
@@ -26,7 +26,7 @@ When a quest is held, append `(HELD)` to its phase and include the hold reason i
 When companies are defined, group quests by company in the status report:
 
 ```
-## Company: API Work (2/3 quests in Implement+)
+## Company: API Work (1/2 quests in Implement+)
 
 | Task | Type | Phase | Progress |
 |------|------|-------|----------|

--- a/plugin/skills/fellowship/resources/progress-tracking.md
+++ b/plugin/skills/fellowship/resources/progress-tracking.md
@@ -14,8 +14,8 @@ When the user asks for "status" or Gandalf proactively reports progress:
 
 | Task | Type | Phase | Progress |
 |------|------|-------|----------|
-| quest-auth-bug | Quest | Implement | ████░░ 3/5 |
-| quest-rate-limit | Quest | Research (HELD) | █░░░░░ 1/5 |
+| quest-auth-bug | Quest | Implement | ███░░░ 3/6 |
+| quest-rate-limit | Quest | Research (HELD) | █░░░░░ 1/6 |
 | scout-auth-analysis | Scout | Validating | ██░░ 2/3 |
 
 **Quests:** 2 active (1 held) | **Scouts:** 1 active | **Completed:** 0
@@ -30,21 +30,21 @@ When companies are defined, group quests by company in the status report:
 
 | Task | Type | Phase | Progress |
 |------|------|-------|----------|
-| quest-add-endpoint | Quest | Implement | ████░░ 3/5 |
-| quest-add-tests | Quest | Research | █░░░░░ 1/5 |
+| quest-add-endpoint | Quest | Implement | ███░░░ 3/6 |
+| quest-add-tests | Quest | Research | █░░░░░ 1/6 |
 | scout-review-api | Scout | Investigating | █░░ 1/3 |
 
 ## Ungrouped
 
 | Task | Type | Phase | Progress |
 |------|------|-------|----------|
-| quest-other-task | Quest | Plan | ██░░░░ 2/5 |
+| quest-other-task | Quest | Plan | ██░░░░ 2/6 |
 ```
 
 ## Phase-to-Progress Mapping
 
 Quest phases:
-- Onboard = 0/5, Research = 1/5, Plan = 2/5, Implement = 3/5, Review = 4/5, Complete = 5/5
+- Onboard = 0/6, Research = 1/6, Plan = 2/6, Implement = 3/6, Adversarial = 4/6, Review = 5/6, Complete = 6/6
 
 Scout phases:
 - Investigating = 1/3, Validating = 2/3, Done = 3/3

--- a/plugin/skills/fellowship/resources/spawn-prompts.md
+++ b/plugin/skills/fellowship/resources/spawn-prompts.md
@@ -1,131 +1,20 @@
 # Spawn Prompts
 
-## Quest Spawn Prompt
+## Quest Spawn Prompt (one base template, three variants)
+
+All quest teammates — **standard**, **plan-driven**, and **promoted** — are spawned from the single base template below. Three placeholders (`{mode_context}`, `{mode_instruction_1}`, `{boundaries_exception}`) carry everything that differs between variants; every other line is shared. When editing gate, hold, isolation, or boundary language, edit the base template once — never fork a per-variant copy.
+
+### Base Template
 
 ```
 You are a quest runner in a fellowship coordinated by Gandalf (the lead).
 
 YOUR TASK: {task_description}
 {issue_context}
+{mode_context}
 
 INSTRUCTIONS:
-1. Run /quest to execute this task through the full quest lifecycle
-2. ISOLATION SELF-CHECK (do this BEFORE any Edit/Write/commit): the lead should
-   have placed you in your own git worktree, but isolation provisioning can
-   silently fail — do NOT assume it worked. Verify before touching anything.
-   Run `git rev-parse --show-toplevel` and `git rev-parse --git-common-dir`.
-   The main repo root is the PARENT of the common git dir. Your top-level MUST
-   NOT equal the main repo root. If it IS the main root, STOP — do not edit,
-   do not commit — and message the lead that you were not isolated. Only
-   proceed once you have confirmed your top-level is a distinct worktree path.
-   Note: the fail-closed `worktree-guard` hook blocks source writes from the
-   main tree — a block is PROOF you are mis-placed, not an obstacle to route
-   around.
-3. Gate handling — gates are enforced by plugin hooks via a state file
-   (.fellowship/quest-state.json). The hooks structurally block your tools
-   after gate submission. Here is how it works:
-
-   Before EACH gate, you MUST:
-   a. Run /lembas to compress context (hooks verify this)
-   b. Run TaskUpdate(taskId: "{task_id}", metadata: {"phase": "<phase>"})
-      to record your current phase (hooks verify this)
-   c. Send ONE gate checklist via SendMessage to the lead.
-      The message content MUST start with [GATE] — e.g.:
-      "[GATE] Research complete\n- [x] Key files identified..."
-      Messages without the [GATE] prefix are not detected as gates.
-
-   After sending a gate message, your Edit/Write/Bash/Agent/Skill tools
-   are blocked by hooks until the lead approves. You cannot bypass this.
-   The lead approves by updating your state file — only the lead can
-   unblock you.
-
-   {gate_config_override}
-
-   NEVER send two gates in one message.
-   NEVER approve your own gates — only the lead can approve.
-   NEVER write "approved" or "proceeding" — that is the lead's language.
-4. The lead may place your quest on hold at any time (e.g., to resolve
-   file conflicts with another quest). When held, your Edit/Write/Bash/
-   Agent/Skill/NotebookEdit tools are structurally blocked — the same
-   mechanism as gate blocking. Wait for the lead to unhold you. The
-   lead will send you a message with updated instructions when you
-   are resumed.
-5. When /quest reaches Phase 5 (Complete), create a PR and message
-   the lead with the PR URL
-6. If you get stuck or need a decision, message the lead
-7. If you receive a shutdown request, respond immediately using
-   SendMessage with type "shutdown_response", approve: true, and
-   the request_id from the message. Do not just acknowledge in text.
-
-CONVENTIONS:
-- Use conventional commits for all git commits (e.g., feat:, fix:, docs:, refactor:)
-
-BOUNDARIES:
-- Stay in YOUR worktree. Do NOT read, write, or navigate into other
-  teammates' worktrees. Your working directory is your worktree root.
-- Do NOT use MCP tools or external service integrations (Notion, Slack,
-  Jira, etc.) without first messaging the lead and getting explicit
-  approval. Your scope is local: code, tests, git, and the filesystem.
-- Do NOT push branches, create PRs, or take any action visible to
-  others without lead approval (except at Phase 5 as instructed above).
-
-CONTEXT:
-- Fellowship team: {team_name}
-- Your quest: {quest_name}
-- Your task ID: {task_id}
-- Other active quests: {brief_list}
-- PR config: {pr_config_line}
-- Base branch: {base_branch}
-{template_guidance}
-```
-
-### Substitution Rules
-
-Before sending the spawn prompt, Gandalf substitutes these placeholders with actual values:
-
-| Placeholder | Source |
-|---|---|
-| `{task_description}` | The quest task text from the user |
-| `{task_id}` | Task ID returned by `TaskCreate` |
-| `{team_name}` | The fellowship team name |
-| `{quest_name}` | Descriptive name (e.g., `"quest-auth-bug"`) |
-| `{brief_list}` | Comma-separated list of other active quest names |
-| `{gate_config_override}` | See below |
-| `{pr_config_line}` | If `config.pr` exists: `"draft=true, template=..."`. If not: `"default (not a draft, no template)"` |
-| `{template_guidance}` | See below |
-| `{issue_context}` | Output from `/missive` if the task references GitHub issues. Empty string if no issues. |
-| `{base_branch}` | The confirmed base branch from startup detection (e.g., `main`, `feat/foo`). |
-
-**`{gate_config_override}` generation (read `config.gates.autoApprove` — default is empty):**
-- **DEFAULT (no config, or `autoApprove` absent/empty):** substitute with `"All gates require lead approval. Do not proceed past any gate without receiving an explicit approval message from the lead."` — do NOT mention auto-approval in any form.
-- **Only if `autoApprove` explicitly lists gate names** (e.g., `["Research", "Plan"]`): substitute with `"The following gates are auto-approved and hooks will advance your state automatically: Research, Plan. For all other gates, your tools are blocked until the lead approves."`
-
-**`{template_guidance}` generation:**
-- **No template selected:** substitute with empty string (no extra content in spawn prompt)
-- **Template selected:** substitute with:
-  ```
-  TEMPLATE: "{template_name}"
-  At the start of each quest phase, invoke /lorebook to load
-  phase-specific guidance for this template.
-  ```
-
-## Plan-Driven Quest Spawn Prompt
-
-Use this template when the user provides a pre-existing plan file for a quest.
-
-```
-You are a quest runner in a fellowship coordinated by Gandalf (the lead).
-
-YOUR TASK: {task_description}
-{issue_context}
-
-PRE-EXISTING PLAN: {plan_path}
-
-INSTRUCTIONS:
-1. Run /quest to execute this task — but with a pre-existing plan:
-   - In Phase 0 (Onboard), copy the plan file to .fellowship/plan.md
-   - The quest skill will detect this file and skip Research + Plan,
-     starting directly at Phase 3 (Implement)
+1. {mode_instruction_1}
 2. ISOLATION SELF-CHECK (do this BEFORE any Edit/Write/commit): the lead should
    have placed you in your own git worktree, but isolation provisioning can
    silently fail — do NOT assume it worked. Verify before touching anything.
@@ -160,98 +49,6 @@ INSTRUCTIONS:
    NEVER send two gates in one message.
    NEVER approve your own gates — only the lead can approve.
    NEVER write "approved" or "proceeding" — that is the lead's language.
-4. The lead may place your quest on hold at any time. When held, your
-   tools are blocked. Wait for the lead to unhold you.
-5. When /quest reaches Phase 5 (Complete), create a PR and message
-   the lead with the PR URL
-6. If you get stuck or need a decision, message the lead
-7. If you receive a shutdown request, respond immediately using
-   SendMessage with type "shutdown_response", approve: true, and
-   the request_id from the message.
-
-CONVENTIONS:
-- Use conventional commits for all git commits (e.g., feat:, fix:, docs:, refactor:)
-
-BOUNDARIES:
-- Stay in YOUR worktree. Do NOT read, write, or navigate into other
-  teammates' worktrees. Exception: you may read {plan_path} once during
-  Onboard to copy it into your worktree.
-- Do NOT use MCP tools or external service integrations without lead approval.
-- Do NOT push branches, create PRs, or take any action visible to
-  others without lead approval (except at Phase 5 as instructed above).
-
-CONTEXT:
-- Fellowship team: {team_name}
-- Your quest: {quest_name}
-- Your task ID: {task_id}
-- Other active quests: {brief_list}
-- PR config: {pr_config_line}
-- Base branch: {base_branch}
-{template_guidance}
-```
-
-### Plan-Driven Substitution Rules
-
-Same substitutions as the standard quest spawn prompt, plus:
-
-| Placeholder | Source |
-|---|---|
-| `{plan_path}` | Absolute path to the plan file in the main repo |
-
-## Promoted Quest Spawn Prompt
-
-Use this variant when promoting a scout's findings into a new quest. The quest enters validation mode in Phase 1 (verifying scout findings instead of full research).
-
-~~~
-You are a quest runner in a fellowship coordinated by Gandalf (the lead).
-
-YOUR TASK: {task_description}
-{issue_context}
-
-PROMOTED FROM: scout "{scout_name}"
-Scout findings are pre-loaded at {findings_path}. Your Phase 1 (Research)
-should validate these findings rather than starting from scratch — see the
-quest skill for validation mode details.
-
-SCOUT FINDINGS CONTENT:
-{scout_findings_content}
-
-INSTRUCTIONS:
-1. Run /quest to execute this task through the full quest lifecycle
-2. ISOLATION SELF-CHECK (do this BEFORE any Edit/Write/commit): the lead should
-   have placed you in your own git worktree, but isolation provisioning can
-   silently fail — do NOT assume it worked. Verify before touching anything.
-   Run `git rev-parse --show-toplevel` and `git rev-parse --git-common-dir`.
-   The main repo root is the PARENT of the common git dir. Your top-level MUST
-   NOT equal the main repo root. If it IS the main root, STOP — do not edit,
-   do not commit — and message the lead that you were not isolated. Only
-   proceed once you have confirmed your top-level is a distinct worktree path.
-   Note: the fail-closed `worktree-guard` hook blocks source writes from the
-   main tree — a block is PROOF you are mis-placed, not an obstacle to route
-   around.
-3. Gate handling — gates are enforced by plugin hooks via a state file
-   (.fellowship/quest-state.json). The hooks structurally block your tools
-   after gate submission. Here is how it works:
-
-   Before EACH gate, you MUST:
-   a. Run /lembas to compress context (hooks verify this)
-   b. Run TaskUpdate(taskId: "{task_id}", metadata: {"phase": "<phase>"})
-      to record your current phase (hooks verify this)
-   c. Send ONE gate checklist via SendMessage to the lead.
-      The message content MUST start with [GATE] — e.g.:
-      "[GATE] Research complete\n- [x] Key files identified..."
-      Messages without the [GATE] prefix are not detected as gates.
-
-   After sending a gate message, your Edit/Write/Bash/Agent/Skill tools
-   are blocked by hooks until the lead approves. You cannot bypass this.
-   The lead approves by updating your state file — only the lead can
-   unblock you.
-
-   {gate_config_override}
-
-   NEVER send two gates in one message.
-   NEVER approve your own gates — only the lead can approve.
-   NEVER write "approved" or "proceeding" — that is the lead's language.
 4. The lead may place your quest on hold at any time (e.g., to resolve
    file conflicts with another quest). When held, your Edit/Write/Bash/
    Agent/Skill/NotebookEdit tools are structurally blocked — the same
@@ -270,7 +67,7 @@ CONVENTIONS:
 
 BOUNDARIES:
 - Stay in YOUR worktree. Do NOT read, write, or navigate into other
-  teammates' worktrees. Your working directory is your worktree root.
+  teammates' worktrees. Your working directory is your worktree root.{boundaries_exception}
 - Do NOT use MCP tools or external service integrations (Notion, Slack,
   Jira, etc.) without first messaging the lead and getting explicit
   approval. Your scope is local: code, tests, git, and the filesystem.
@@ -285,17 +82,91 @@ CONTEXT:
 - PR config: {pr_config_line}
 - Base branch: {base_branch}
 {template_guidance}
-~~~
+```
 
-### Promoted Quest Substitution Rules
+### Substitution Rules (all variants)
 
-Same substitutions as the standard quest spawn prompt, plus:
+Before sending the spawn prompt, Gandalf substitutes these placeholders with actual values:
 
 | Placeholder | Source |
 |---|---|
+| `{task_description}` | The quest task text from the user |
+| `{task_id}` | Task ID returned by `TaskCreate` |
+| `{team_name}` | The fellowship team name |
+| `{quest_name}` | Descriptive name (e.g., `"quest-auth-bug"`) |
+| `{brief_list}` | Comma-separated list of other active quest names |
+| `{gate_config_override}` | See below |
+| `{pr_config_line}` | If `config.pr` exists: `"draft=true, template=..."`. If not: `"default (not a draft, no template)"` |
+| `{template_guidance}` | See below |
+| `{issue_context}` | Output from `/missive` if the task references GitHub issues. Empty string if no issues. |
+| `{base_branch}` | The confirmed base branch from startup detection (e.g., `main`, `feat/foo`). |
+| `{mode_context}`, `{mode_instruction_1}`, `{boundaries_exception}` | Per-variant — see the variant sections below |
+
+**`{gate_config_override}` generation (read `config.gates.autoApprove` — default is empty):**
+- **DEFAULT (no config, or `autoApprove` absent/empty):** substitute with `"All gates require lead approval. Do not proceed past any gate without receiving an explicit approval message from the lead."` — do NOT mention auto-approval in any form.
+- **Only if `autoApprove` explicitly lists gate names** (e.g., `["Research", "Plan"]`): substitute with `"The following gates are auto-approved and hooks will advance your state automatically: Research, Plan. For all other gates, your tools are blocked until the lead approves."`
+
+**`{template_guidance}` generation:**
+- **No template selected:** substitute with empty string (no extra content in spawn prompt)
+- **Template selected:** substitute with:
+  ```
+  TEMPLATE: "{template_name}"
+  At the start of each quest phase, invoke /lorebook to load
+  phase-specific guidance for this template.
+  ```
+
+### Variant: Standard
+
+| Placeholder | Value |
+|---|---|
+| `{mode_context}` | Empty string |
+| `{mode_instruction_1}` | `Run /quest to execute this task through the full quest lifecycle` |
+| `{boundaries_exception}` | Empty string |
+
+### Variant: Plan-Driven
+
+Use when the user provides a pre-existing plan file for a quest.
+
+| Placeholder | Value |
+|---|---|
+| `{mode_context}` | `PRE-EXISTING PLAN: {plan_path}` |
+| `{mode_instruction_1}` | See below |
+| `{boundaries_exception}` | ` Exception: you may read {plan_path} once during Onboard to copy it into your worktree.` |
+| `{plan_path}` | Absolute path to the plan file in the main repo |
+
+`{mode_instruction_1}` for plan-driven:
+
+```
+Run /quest to execute this task — but with a pre-existing plan:
+   - In Phase 0 (Onboard), copy the plan file to .fellowship/plan.md
+   - The quest skill will detect this file and skip Research + Plan,
+     starting directly at Phase 3 (Implement)
+```
+
+### Variant: Promoted
+
+Use when promoting a scout's findings into a new quest. The quest enters validation mode in Phase 1 (verifying scout findings instead of full research).
+
+| Placeholder | Value |
+|---|---|
+| `{mode_context}` | See below |
+| `{mode_instruction_1}` | `Run /quest to execute this task through the full quest lifecycle` (same as Standard) |
+| `{boundaries_exception}` | Empty string |
 | `{scout_name}` | Name of the scout being promoted (e.g., `"scout-auth-analysis"`) |
 | `{findings_path}` | Path to the scout findings file: `.fellowship/scout-findings-{scout_name}.md` (using configured `dataDir` if overridden) |
 | `{scout_findings_content}` | Full content of the scout findings file, pasted inline so the quest can write it to its worktree |
+
+`{mode_context}` for promoted:
+
+```
+PROMOTED FROM: scout "{scout_name}"
+Scout findings are pre-loaded at {findings_path}. Your Phase 1 (Research)
+should validate these findings rather than starting from scratch — see the
+quest skill for validation mode details.
+
+SCOUT FINDINGS CONTENT:
+{scout_findings_content}
+```
 
 ## Scout Spawn Prompt
 

--- a/plugin/skills/fellowship/resources/spawn-prompts.md
+++ b/plugin/skills/fellowship/resources/spawn-prompts.md
@@ -11,6 +11,7 @@ You are a quest runner in a fellowship coordinated by Gandalf (the lead).
 
 YOUR TASK: {task_description}
 {issue_context}
+
 {mode_context}
 
 INSTRUCTIONS:
@@ -36,7 +37,7 @@ INSTRUCTIONS:
       to record your current phase (hooks verify this)
    c. Send ONE gate checklist via SendMessage to the lead.
       The message content MUST start with [GATE] — e.g.:
-      "[GATE] Implement complete\n- [x] All plan tasks done..."
+      "[GATE] Research complete\n- [x] Key files identified..."
       Messages without the [GATE] prefix are not detected as gates.
 
    After sending a gate message, your Edit/Write/Bash/Agent/Skill tools
@@ -102,6 +103,8 @@ Before sending the spawn prompt, Gandalf substitutes these placeholders with act
 | `{base_branch}` | The confirmed base branch from startup detection (e.g., `main`, `feat/foo`). |
 | `{mode_context}`, `{mode_instruction_1}`, `{boundaries_exception}` | Per-variant — see the variant sections below |
 
+**Resolution is recursive.** Variant values may themselves contain placeholders (`{plan_path}`, `{scout_name}`, `{findings_path}`, `{scout_findings_content}`). After inserting a variant's values into the base template, substitute again until no `{placeholder}` remains anywhere in the outgoing prompt — never send a prompt containing a literal unresolved placeholder.
+
 **`{gate_config_override}` generation (read `config.gates.autoApprove` — default is empty):**
 - **DEFAULT (no config, or `autoApprove` absent/empty):** substitute with `"All gates require lead approval. Do not proceed past any gate without receiving an explicit approval message from the lead."` — do NOT mention auto-approval in any form.
 - **Only if `autoApprove` explicitly lists gate names** (e.g., `["Research", "Plan"]`): substitute with `"The following gates are auto-approved and hooks will advance your state automatically: Research, Plan. For all other gates, your tools are blocked until the lead approves."`
@@ -142,6 +145,8 @@ Run /quest to execute this task — but with a pre-existing plan:
    - The quest skill will detect this file and skip Research + Plan,
      starting directly at Phase 3 (Implement)
 ```
+
+Note: a plan-driven quest's first gate is Implement (e.g. `[GATE] Implement complete`) — the base template's Research example does not apply to this variant.
 
 ### Variant: Promoted
 
@@ -212,7 +217,9 @@ goes wrong. You never write code or run quests.
 
 MONITORING CHECKLIST:
 1. Use TaskList to check quest progress — each quest updates its task
-   metadata with a "phase" field (Onboard/Research/Plan/Implement/Review/Complete)
+   metadata with a "phase" field (Onboard/Research/Plan/Implement/Adversarial/Review/Complete).
+   A quest sitting in Adversarial is usually waiting on a balrog review run —
+   that phase legitimately takes a while; do not flag it as stuck prematurely.
 2. Flag quests that appear stuck (phase hasn't advanced, no gate messages)
 3. Check worktree diffs for scope drift — compare modified files against
    the task description

--- a/plugin/skills/gather-lore/SKILL.md
+++ b/plugin/skills/gather-lore/SKILL.md
@@ -32,6 +32,8 @@ If the user can't identify any:
 
 ### Step 2: Extract Patterns
 
+<!-- This taxonomy deliberately mirrors warden/SKILL.md Step 3 (Reference Comparison): gather-lore extracts along the same dimensions warden later checks. Change both files together. Same for Step 4 below, which mirrors warden Step 6 (Learn). -->
+
 Read each reference file and produce a structured analysis. Be exhaustive — the patterns you miss are the ones that get flagged in review:
 
 ```

--- a/plugin/skills/gather-lore/SKILL.md
+++ b/plugin/skills/gather-lore/SKILL.md
@@ -32,7 +32,6 @@ If the user can't identify any:
 
 ### Step 2: Extract Patterns
 
-<!-- This taxonomy deliberately mirrors warden/SKILL.md Step 3 (Reference Comparison): gather-lore extracts along the same dimensions warden later checks. Change both files together. Same for Step 4 below, which mirrors warden Step 6 (Learn). -->
 
 Read each reference file and produce a structured analysis. Be exhaustive — the patterns you miss are the ones that get flagged in review:
 

--- a/plugin/skills/lembas/SKILL.md
+++ b/plugin/skills/lembas/SKILL.md
@@ -9,12 +9,12 @@ description: Use between workflow phases or when context feels bloated. Compress
 
 Compresses the current conversation into a structured summary to keep the context window in the "smart zone." This is the intentional compaction pattern from context engineering — proactively trimming context between phases rather than waiting for overflow.
 
-The ~40% context utilization mark is where reasoning quality starts to degrade. This skill is the mechanism for staying under that threshold.
+Reasoning quality degrades as a context window fills — well before it overflows. This skill is the mechanism for staying in the sweet spot by compacting early and often.
 
 ## When to Use
 
 - Between phases of the quest workflow (invoked automatically by `/quest`)
-- When a conversation feels bloated after verbose output (build logs, long file reads, exploratory searches)
+- After any stretch of verbose output you would not re-read (build logs, long file reads, exploratory searches, failed-attempt noise) — if in doubt, compact
 - Before switching focus within a session
 - Standalone via `/lembas`
 

--- a/plugin/skills/quest/SKILL.md
+++ b/plugin/skills/quest/SKILL.md
@@ -122,7 +122,7 @@ After resume setup, proceed to the gate for Phase 0 as normal (run /lembas, upda
 
 #### Standard Onboard
 
-1. **Config:** Read `~/.claude/fellowship.json` (the user's personal Claude directory) if it exists. Merge with defaults (see fellowship skill for the full schema). If the file does not exist, all defaults apply.
+1. **Config:** Read both config layers if they exist — project `.fellowship/config.json` (repo root) and user `~/.claude/fellowship.json` — and merge as defaults → project → user (user wins; see `/settings` for the full schema). If neither file exists, all defaults apply.
 2. **Isolate:** Detect whether you're resuming an existing worktree: check if task metadata contains `worktree_path` (via `TaskGet`) and the path exists on disk. If so, you're already isolated — skip worktree creation. Otherwise, if `config.worktree.enabled` is true (default), create an isolated worktree:
    - **Resolve branch name:** If the spawn prompt includes issue context from `/missive` with a suggested branch name, use that name directly (it already incorporates the issue number and title). Otherwise, determine the branch name using config:
      1. If `branch.pattern` is set: substitute `{slug}`, `{ticket}`, `{author}` placeholders (see below).
@@ -298,7 +298,7 @@ Goal: Find failure modes before conventions and code quality review. Spawn balro
 1. Spawn the balrog agent via the Agent tool, passing:
    - The worktree path (from Session Context / task metadata)
    - The task description
-   - Your task ID (so balrog can report back via SendMessage)
+   - Your teammate name (so balrog can report back via SendMessage — recipients are addressed by name, not task ID). If running /quest standalone (no fellowship), tell balrog to present findings directly instead.
    - Model: only if `models.balrog` is set in config, pass it as the Agent tool's `model` parameter; otherwise omit it — balrog inherits the session model by default. Adversarial review is not a place to economize unless the user opted in.
 2. Wait for balrog's SendMessage report. If balrog does not respond within a reasonable time (or if you receive an error from the Agent tool), proceed to Phase 4 and note in your gate message that adversarial review was skipped due to agent failure.
 3. Evaluate findings by severity:

--- a/plugin/skills/quest/SKILL.md
+++ b/plugin/skills/quest/SKILL.md
@@ -58,6 +58,8 @@ Phase 5: Complete ───→ finishing-a-development-branch
 
 ## Process
 
+**External skill dependencies:** Several steps invoke skills from the `superpowers` and `pr-review-toolkit` plugins (TDD, verification, branch finishing, PR review). If an invocation fails because the plugin is not installed, do not silently skip the step — perform the step's goal manually (write the failing test first yourself, run the verification commands yourself, review the diff yourself) and note the substitution in your phase output or gate message.
+
 ### Fellowship Integration
 
 When running as a fellowship teammate (indicated by the spawn prompt), the gate prerequisite order at the end of each phase is:
@@ -107,10 +109,10 @@ If the spawn prompt contains a `RESUME CONTEXT:` block, this is a recovered ques
 
 1. **Skip worktree creation** — your worktree already exists and you're already in it
 2. **Reset state file:** Run `fellowship init --dir $(pwd)` (you're already in the worktree) to clear `gate_pending` while preserving the current phase
-4. **Update task metadata:** `TaskUpdate(taskId: "<task_id>", metadata: {"worktree_path": "<cwd>"})` with the new task ID from the recovery spawn
-5. **Load checkpoint:** If `.fellowship/checkpoint.md` exists, read it as your initial context — this replaces `/council` orientation
-6. **Skip `/council`** — the checkpoint provides equivalent context from the previous session
-7. **Jump to current phase:** Begin executing from the phase recorded in the state file (e.g., if phase is "Implement", skip Research and Plan, go directly to Implement)
+3. **Update task metadata:** `TaskUpdate(taskId: "<task_id>", metadata: {"worktree_path": "<cwd>"})` with the new task ID from the recovery spawn
+4. **Load checkpoint:** If `.fellowship/checkpoint.md` exists, read it as your initial context — this replaces `/council` orientation
+5. **Skip `/council`** — the checkpoint provides equivalent context from the previous session
+6. **Jump to current phase:** Begin executing from the phase recorded in the state file (e.g., if phase is "Implement", skip Research and Plan, go directly to Implement)
 
 On respawn, your tome at `.fellowship/quest-tome.json` contains your full history — phases completed, gates passed/rejected, files touched. Use this to orient faster than the checkpoint alone.
 
@@ -210,7 +212,7 @@ The same hard gate requirements apply — validation mode doesn't lower the bar,
    - both flags together when both are available
    Incorporate any relevant findings into your research.
 3. If entering an unfamiliar area, invoke `/gather-lore` to extract conventions from reference files
-4. Use Explore agents (Task tool, subagent_type=Explore) to scan relevant code paths
+4. Use Explore agents (Agent tool, subagent_type=Explore) to scan relevant code paths
 5. Read key files identified in the Session Context
 6. Document findings: how the current system works, constraints, edge cases
 
@@ -255,7 +257,7 @@ Goal: Execute the plan with small, verifiable changes and tight feedback loops. 
 4. Commit each logical unit
 
 **Parallel subagents:** Plan has 3+ independent tasks touching different files.
-1. Dispatch multiple implementation subagents simultaneously (multiple Task tool calls in one message)
+1. Dispatch multiple implementation subagents simultaneously (multiple Agent tool calls in one message)
 2. Each subagent gets the full task text, relevant context, and TDD instructions
 3. No two subagents modify the same file — this is a planning constraint, not a runtime guard. If the plan has file conflicts between subtasks, fix the plan.
 4. Collect results, review each, then commit

--- a/plugin/skills/quest/SKILL.md
+++ b/plugin/skills/quest/SKILL.md
@@ -212,7 +212,7 @@ The same hard gate requirements apply — validation mode doesn't lower the bar,
    - both flags together when both are available
    Incorporate any relevant findings into your research.
 3. If entering an unfamiliar area, invoke `/gather-lore` to extract conventions from reference files
-4. Use Explore agents (Agent tool, subagent_type=Explore) to scan relevant code paths
+4. Use Explore agents (Agent tool, subagent_type=Explore, passing `model: "haiku"` — or `models.explore` from config if set) to scan relevant code paths
 5. Read key files identified in the Session Context
 6. Document findings: how the current system works, constraints, edge cases
 
@@ -299,6 +299,7 @@ Goal: Find failure modes before conventions and code quality review. Spawn balro
    - The worktree path (from Session Context / task metadata)
    - The task description
    - Your task ID (so balrog can report back via SendMessage)
+   - Model: only if `models.balrog` is set in config, pass it as the Agent tool's `model` parameter; otherwise omit it — balrog inherits the session model by default. Adversarial review is not a place to economize unless the user opted in.
 2. Wait for balrog's SendMessage report. If balrog does not respond within a reasonable time (or if you receive an error from the Agent tool), proceed to Phase 4 and note in your gate message that adversarial review was skipped due to agent failure.
 3. Evaluate findings by severity:
    - **Critical/High** — must address before Review gate opens. Fix, re-run relevant tests, then confirm fixes with balrog's reproduction steps.

--- a/plugin/skills/scout/SKILL.md
+++ b/plugin/skills/scout/SKILL.md
@@ -53,7 +53,7 @@ Goal: Adversarially verify findings using a fresh subagent with no context pollu
 - Deep analysis involving multiple systems or complex interactions
 - Findings that will inform architectural decisions or code changes
 - Questions where being wrong would waste significant downstream effort
-- Any time there are Medium or Low confidence findings that matter
+- Any Medium or Low confidence finding that appears in a conclusion or recommendation of the report (if it's load-bearing, it gets validated)
 
 **When to skip validation:**
 - Simple lookups ("where is X defined?")

--- a/plugin/skills/scout/SKILL.md
+++ b/plugin/skills/scout/SKILL.md
@@ -29,7 +29,7 @@ Goal: Gather thorough, factual findings about the question.
 
 **Actions:**
 1. Invoke `/council` to load task-relevant context
-2. Use Explore agents (Agent tool, subagent_type=Explore) to scan relevant code paths
+2. Use Explore agents (Agent tool, subagent_type=Explore, passing `model: "haiku"` — or `models.explore` from fellowship config if set) to scan relevant code paths
 3. Read key files, trace call chains, understand behavior
 4. Document findings with specific file paths and line references
 
@@ -62,7 +62,7 @@ Goal: Adversarially verify findings using a fresh subagent with no context pollu
 
 **Validation procedure:**
 1. Write your findings to a working file (e.g., `docs/research/<topic>.md`) — do NOT commit
-2. Spawn a validator subagent via the Agent tool with subagent_type "general-purpose":
+2. Spawn a validator subagent via the Agent tool with subagent_type "general-purpose", passing `model: "sonnet"` (or `models.validator` from fellowship config if set) — validation is evidence-checking against specific files, not deep synthesis:
 
 ```
 You are a research validator. Your job is adversarial: challenge

--- a/plugin/skills/scout/SKILL.md
+++ b/plugin/skills/scout/SKILL.md
@@ -62,28 +62,11 @@ Goal: Adversarially verify findings using a fresh subagent with no context pollu
 
 **Validation procedure:**
 1. Write your findings to a working file (e.g., `docs/research/<topic>.md`) — do NOT commit
-2. Spawn a validator subagent via the Agent tool with subagent_type "general-purpose", passing `model: "sonnet"` (or `models.validator` from fellowship config if set) — validation is evidence-checking against specific files, not deep synthesis:
+2. Spawn a validator subagent via the Agent tool with subagent_type `"fellowship:validator"` — a read-only agent (Read/Glob/Grep only, enforced by tool restrictions; defaults to sonnet, or pass `models.validator` from fellowship config as the `model` parameter). The agent definition carries the validation procedure; the spawn prompt only needs the material:
 
 ```
-You are a research validator. Your job is adversarial: challenge
-assumptions, verify factual claims, and flag anything wrong or unsupported.
-
 FINDINGS TO VALIDATE:
 <paste findings here, including file paths and line references>
-
-INSTRUCTIONS:
-1. For each factual claim, read the referenced file and line range.
-   Does the code actually do what the finding says?
-2. For each Medium/Low confidence finding, investigate independently.
-   Can you confirm or refute it?
-3. Produce a validation report:
-   - CONFIRMED: claims you verified are correct
-   - CONTESTED: claims that are wrong or misleading, with evidence
-   - UNVERIFIED: claims you couldn't confirm or deny
-
-BOUNDARIES:
-- Read any file. Do NOT modify any files or run commands.
-- Be adversarial — your value is in catching errors, not agreeing.
 ```
 
 3. Review the validation report

--- a/plugin/skills/scout/SKILL.md
+++ b/plugin/skills/scout/SKILL.md
@@ -62,7 +62,7 @@ Goal: Adversarially verify findings using a fresh subagent with no context pollu
 
 **Validation procedure:**
 1. Write your findings to a working file (e.g., `docs/research/<topic>.md`) — do NOT commit
-2. Spawn a validator subagent via the Agent tool with subagent_type `"fellowship:validator"` — a read-only agent (Read/Glob/Grep only, enforced by tool restrictions; defaults to sonnet, or pass `models.validator` from fellowship config as the `model` parameter). The agent definition carries the validation procedure; the spawn prompt only needs the material:
+2. Spawn a validator subagent via the Agent tool with subagent_type `"fellowship:validator"` — a read-only agent (Read/Glob/Grep only, enforced by tool restrictions). If `models.validator` is set in fellowship config, pass it as the Agent tool's `model` parameter; otherwise omit the parameter (the agent definition defaults to sonnet). The agent definition carries the validation procedure; the spawn prompt only needs the material:
 
 ```
 FINDINGS TO VALIDATE:

--- a/plugin/skills/warden/SKILL.md
+++ b/plugin/skills/warden/SKILL.md
@@ -43,7 +43,6 @@ For every rule in `## Review Conventions`, check compliance:
 
 ### Step 3: Reference Comparison
 
-<!-- These dimensions deliberately mirror gather-lore/SKILL.md Step 2 (Extract Patterns): warden checks along the same dimensions gather-lore extracts. Change both files together. Same for Step 6 below, which mirrors gather-lore Step 4. -->
 
 Compare your code against reference files across every dimension:
 

--- a/plugin/skills/warden/SKILL.md
+++ b/plugin/skills/warden/SKILL.md
@@ -43,6 +43,8 @@ For every rule in `## Review Conventions`, check compliance:
 
 ### Step 3: Reference Comparison
 
+<!-- These dimensions deliberately mirror gather-lore/SKILL.md Step 2 (Extract Patterns): warden checks along the same dimensions gather-lore extracts. Change both files together. Same for Step 6 below, which mirrors gather-lore Step 4. -->
+
 Compare your code against reference files across every dimension:
 
 **Structure**

--- a/site/src/routes/agents/+page.svelte
+++ b/site/src/routes/agents/+page.svelte
@@ -151,6 +151,33 @@
 					(configurable via <code>models.scout</code>).
 				</div>
 			</div>
+
+			<!-- Validator -->
+			<div class="agent-card animate-in" style="animation-delay: 400ms">
+				<div class="agent-header">
+					<div class="agent-icon">
+						<svg viewBox="0 0 48 48" width="48" height="48" fill="none" xmlns="http://www.w3.org/2000/svg">
+							<circle cx="24" cy="24" r="16" stroke="currentColor" stroke-width="1.5" opacity="0.5" />
+							<path d="M17 24 L22 29 L31 19" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" opacity="0.9" />
+							<circle cx="24" cy="24" r="20" stroke="currentColor" stroke-width="1" opacity="0.15" />
+						</svg>
+					</div>
+					<div>
+						<h3 class="agent-name">Validator</h3>
+						<span class="agent-role">Findings Verifier</span>
+					</div>
+				</div>
+				<p class="agent-desc">
+					Read-only adversarial verifier spawned by scout during its Validate phase.
+					Re-reads every referenced file and line range, challenges assumptions, and
+					reports each claim as CONFIRMED, CONTESTED, or UNVERIFIED.
+				</p>
+				<div class="agent-note">
+					Tools restricted to Read, Glob, and Grep — cannot modify files or run commands.
+					Uses the <code>sonnet</code> model by default (configurable via
+					<code>models.validator</code>).
+				</div>
+			</div>
 		</div>
 	</div>
 </section>

--- a/site/src/routes/agents/+page.svelte
+++ b/site/src/routes/agents/+page.svelte
@@ -53,7 +53,8 @@
 					Reports issues to Gandalf for intervention.
 				</p>
 				<div class="agent-note config-note">
-					Enabled by default. Spawns at 2+ active quests. Configure via
+					Enabled by default. Spawns at 2+ active quests. Uses the <code>haiku</code> model by
+					default (configurable via <code>models.palantir</code>). Configure via
 					<code>palantir.enabled</code> and <code>palantir.minQuests</code> in settings.
 				</div>
 			</div>
@@ -146,7 +147,8 @@
 				</p>
 				<div class="agent-note">
 					Spawned via <code>scout: &lt;question&gt;</code> in fellowship descriptions.
-					No gates, no hooks, no commits.
+					No gates, no hooks, no commits. Uses the <code>sonnet</code> model by default
+					(configurable via <code>models.scout</code>).
 				</div>
 			</div>
 		</div>

--- a/site/src/routes/configuration/+page.svelte
+++ b/site/src/routes/configuration/+page.svelte
@@ -144,7 +144,7 @@
 		{
 			key: 'models.quest',
 			default_val: 'null',
-			desc: 'Model for quest teammates. A model alias (haiku, sonnet, opus), a full model ID, or "inherit". null = built-in default: inherit the session model.'
+			desc: 'Model for quest teammates. Valid values: "haiku", "sonnet", "opus" (aliases only — spawn parameters accept neither "inherit" nor full model IDs; leave null to inherit). null = built-in default: inherit the session model.'
 		},
 		{
 			key: 'models.scout',
@@ -164,7 +164,7 @@
 		{
 			key: 'models.explore',
 			default_val: 'null',
-			desc: 'Model for Explore scan subagents spawned by quest, scout, and council. Same valid values. null = built-in default: haiku.'
+			desc: 'Model for Explore scan subagents spawned by quest, scout, council, and guide. Same valid values. null = built-in default: haiku.'
 		},
 		{
 			key: 'models.validator',

--- a/site/src/routes/configuration/+page.svelte
+++ b/site/src/routes/configuration/+page.svelte
@@ -22,6 +22,17 @@
   "palantir": {
     "enabled": true,
     "minQuests": 2
+  },
+  "issues": {
+    "autoClose": true
+  },
+  "models": {
+    "quest": null,
+    "scout": null,
+    "palantir": null,
+    "balrog": null,
+    "explore": null,
+    "validator": null
   }
 }`;
 
@@ -124,6 +135,41 @@
 			key: 'palantir.minQuests',
 			default_val: '2',
 			desc: 'Minimum active quests before palantir is spawned.'
+		},
+		{
+			key: 'issues.autoClose',
+			default_val: 'true',
+			desc: 'When true, /missive includes "Closes #N" in PR keywords so issues close on merge.'
+		},
+		{
+			key: 'models.quest',
+			default_val: 'null',
+			desc: 'Model for quest teammates. A model alias (haiku, sonnet, opus), a full model ID, or "inherit". null = built-in default: inherit the session model.'
+		},
+		{
+			key: 'models.scout',
+			default_val: 'null',
+			desc: 'Model for scout teammates. Same valid values. null = built-in default: sonnet.'
+		},
+		{
+			key: 'models.palantir',
+			default_val: 'null',
+			desc: 'Model for the palantir monitor. Same valid values. null = built-in default: haiku.'
+		},
+		{
+			key: 'models.balrog',
+			default_val: 'null',
+			desc: 'Model for balrog adversarial review. Same valid values. null = built-in default: inherit the session model.'
+		},
+		{
+			key: 'models.explore',
+			default_val: 'null',
+			desc: 'Model for Explore scan subagents spawned by quest, scout, and council. Same valid values. null = built-in default: haiku.'
+		},
+		{
+			key: 'models.validator',
+			default_val: 'null',
+			desc: 'Model for scout\'s validation subagent. Same valid values. null = built-in default: sonnet.'
 		}
 	];
 

--- a/site/src/routes/getting-started/+page.svelte
+++ b/site/src/routes/getting-started/+page.svelte
@@ -104,7 +104,7 @@
 
 		<p class="note">
 			These are referenced by name in skill prompts. If a dependency isn't installed,
-			Claude will skip that step rather than fail -- but you lose the discipline that step provides.
+			Claude performs the step's goal manually and notes the substitution -- but you lose the structured discipline the dedicated skill provides.
 		</p>
 	</section>
 

--- a/site/src/routes/skills/+page.svelte
+++ b/site/src/routes/skills/+page.svelte
@@ -10,7 +10,7 @@
 		{
 			name: '/fellowship',
 			summary: 'Multi-task orchestrator. Spawns parallel agent teammates.',
-			details: 'For multiple independent tasks, Gandalf (the coordinator) spawns quest and scout teammates. Quests run in isolated worktrees and produce PRs. Scouts research questions and deliver findings. Say ‘status’ during a fellowship for a progress table. Gates surface to you for approval by default. Supports plan-driven quests: provide a plan file and Gandalf spawns quests that skip to Implement. For large plans, Gandalf can fan out into multiple parallel quests after confirming the split with you. Supports scout-to-quest promotion: say ‘promote scout-X to a quest’ and Gandalf spawns a quest pre-loaded with the scout’s findings. The bulletin board enables cross-quest knowledge sharing — cleared automatically on disband.'
+			details: 'For multiple independent tasks, Gandalf (the coordinator) spawns quest and scout teammates. Quests run in isolated worktrees and produce PRs. Scouts research questions and deliver findings. Say \'status\' during a fellowship for a progress table. Gates surface to you for approval by default. Supports plan-driven quests: provide a plan file and Gandalf spawns quests that skip to Implement. For large plans, Gandalf can fan out into multiple parallel quests after confirming the split with you. Supports scout-to-quest promotion: say \'promote scout-X to a quest\' and Gandalf spawns a quest pre-loaded with the scout\'s findings. The bulletin board enables cross-quest knowledge sharing — cleared automatically on disband.'
 		},
 		{
 			name: '/scout',
@@ -124,14 +124,14 @@
 	<p class="group-intro">Run only when you type them — no automatic invocation, no base context cost.</p>
 
 	<div class="skills-list">
-		{#each commands as skill, i (skill.name)}
+		{#each commands as command, i (command.name)}
 			<details class="skill-card animate-in" style="animation-delay: {i * 100}ms">
 				<summary>
 					<span class="chevron" aria-hidden="true"></span>
-					<code class="skill-name">{skill.name}</code>
-					<span class="skill-summary">{skill.summary}</span>
+					<code class="skill-name">{command.name}</code>
+					<span class="skill-summary">{command.summary}</span>
 				</summary>
-				<p class="skill-details">{skill.details}</p>
+				<p class="skill-details">{command.details}</p>
 			</details>
 		{/each}
 	</div>

--- a/site/src/routes/skills/+page.svelte
+++ b/site/src/routes/skills/+page.svelte
@@ -4,18 +4,18 @@
 	const skills = [
 		{
 			name: '/quest',
-			summary: 'Full Research \u2192 Plan \u2192 Implement lifecycle for non-trivial tasks.',
-			details: 'The hub skill that orchestrates everything. Takes a task description, creates an isolated worktree, and walks through six phases: Onboard, Research, Plan, Implement, Review, Complete. In standard mode, each phase has a hard gate requiring approval before proceeding. Uses /council for context, /gather-lore for conventions, /lembas for context compression between phases, and /warden for pre-PR review. Supports plan-driven mode: provide a pre-existing plan file and the quest skips Research and Plan, jumping straight to Implement. Supports promoted mode: when a quest is promoted from a scout, Phase 1 enters validation mode \u2014 verifying and supplementing scout findings instead of researching from scratch. Includes a bulletin board for cross-quest knowledge sharing: quests scan the bulletin at Research start and post discoveries during Research and Implement. The bulletin is shared across all worktrees via the main repo root.'
+			summary: 'Full Research → Plan → Implement lifecycle for non-trivial tasks.',
+			details: 'The hub skill that orchestrates everything. Takes a task description, creates an isolated worktree, and walks through six phases: Onboard, Research, Plan, Implement, Review, Complete. In standard mode, each phase has a hard gate requiring approval before proceeding. Uses /council for context, /gather-lore for conventions, /lembas for context compression between phases, and /warden for pre-PR review. Supports plan-driven mode: provide a pre-existing plan file and the quest skips Research and Plan, jumping straight to Implement. Supports promoted mode: when a quest is promoted from a scout, Phase 1 enters validation mode — verifying and supplementing scout findings instead of researching from scratch. Includes a bulletin board for cross-quest knowledge sharing: quests scan the bulletin at Research start and post discoveries during Research and Implement. The bulletin is shared across all worktrees via the main repo root.'
 		},
 		{
 			name: '/fellowship',
 			summary: 'Multi-task orchestrator. Spawns parallel agent teammates.',
-			details: 'For multiple independent tasks, Gandalf (the coordinator) spawns quest and scout teammates. Quests run in isolated worktrees and produce PRs. Scouts research questions and deliver findings. Say \u2018status\u2019 during a fellowship for a progress table. Gates surface to you for approval by default. Supports plan-driven quests: provide a plan file and Gandalf spawns quests that skip to Implement. For large plans, Gandalf can fan out into multiple parallel quests after confirming the split with you. Supports scout-to-quest promotion: say \u2018promote scout-X to a quest\u2019 and Gandalf spawns a quest pre-loaded with the scout\u2019s findings. The bulletin board enables cross-quest knowledge sharing \u2014 cleared automatically on disband.'
+			details: 'For multiple independent tasks, Gandalf (the coordinator) spawns quest and scout teammates. Quests run in isolated worktrees and produce PRs. Scouts research questions and deliver findings. Say ‘status’ during a fellowship for a progress table. Gates surface to you for approval by default. Supports plan-driven quests: provide a plan file and Gandalf spawns quests that skip to Implement. For large plans, Gandalf can fan out into multiple parallel quests after confirming the split with you. Supports scout-to-quest promotion: say ‘promote scout-X to a quest’ and Gandalf spawns a quest pre-loaded with the scout’s findings. The bulletin board enables cross-quest knowledge sharing — cleared automatically on disband.'
 		},
 		{
 			name: '/scout',
 			summary: 'Research & analysis workflow. No code, no PRs, no commits.',
-			details: 'Autonomous research agent that investigates questions with configurable depth. For complex questions, spawns a fresh adversarial validator subagent to verify findings. Produces a structured report with confidence levels. Writes findings to a namespaced file (.fellowship/scout-findings-{name}.md) that can be promoted into a quest. Use alongside /quest in a fellowship for research questions that don\u2019t need code changes.'
+			details: 'Autonomous research agent that investigates questions with configurable depth. For complex questions, spawns a fresh adversarial validator subagent to verify findings. Produces a structured report with confidence levels. Writes findings to a namespaced file (.fellowship/scout-findings-{name}.md) that can be promoted into a quest. Use alongside /quest in a fellowship for research questions that don’t need code changes.'
 		},
 		{
 			name: '/council',
@@ -25,18 +25,36 @@
 		{
 			name: '/gather-lore',
 			summary: 'Studies reference files to extract conventions.',
-			details: 'Analyzes your codebase to extract patterns before writing code. Examines existing implementations to understand naming conventions, file organization, testing patterns, and architectural decisions. Prevents \u2018wrong approach\u2019 rework by learning from what\u2019s already there.'
+			details: 'Analyzes your codebase to extract patterns before writing code. Examines existing implementations to understand naming conventions, file organization, testing patterns, and architectural decisions. Prevents ‘wrong approach’ rework by learning from what’s already there.'
 		},
 		{
 			name: '/lembas',
 			summary: 'Context compression between phases.',
-			details: 'Compacts the conversation context at phase transitions. Keeps the context window in the reasoning sweet spot by summarizing what\u2019s been done and what needs to happen next. Invoked automatically at all four phase transitions during a quest.'
+			details: 'Compacts the conversation context at phase transitions. Keeps the context window in the reasoning sweet spot by summarizing what’s been done and what needs to happen next. Invoked automatically at all four phase transitions during a quest.'
 		},
 		{
 			name: '/warden',
 			summary: 'Pre-PR convention review.',
 			details: 'Compares your changes against reference files and documented patterns in CLAUDE.md. Catches convention violations before they reach PR review. Checks naming, file organization, testing patterns, and architectural consistency.'
 		},
+		{
+			name: '/retro',
+			summary: 'Post-fellowship retrospective analysis.',
+			details: 'Analyzes a completed fellowship’s gate history, palantir alerts, and quest metrics to surface patterns. Identifies which gates added value, which phases caused delays, and interactively recommends configuration changes like auto-approving gates with zero rejection rates.'
+		},
+		{
+			name: '/missive',
+			summary: 'Fetch GitHub issue context for quest spawning.',
+			details: 'Pulls structured context from GitHub issues via gh CLI — title, body, labels, and recent comments. Returns a package with issue context, a suggested branch name incorporating the issue number, and PR closing keywords (Closes #N). Gandalf invokes it automatically when issue references (#N) are detected in quest descriptions. Also usable standalone: /missive 42 to preview what context a quest would receive.'
+		},
+		{
+			name: '/lorebook',
+			summary: 'Load phase-specific guidance from a quest template.',
+			details: 'Invoked at the start of each quest phase when your spawn prompt includes a TEMPLATE: assignment. Resolves the template file from project (.claude/fellowship-templates/) or user (~/.claude/fellowship-templates/) directories, reads the section matching the current phase, and applies the guidance as advisory context. Created via /scribe.'
+		}
+	];
+
+	const commands = [
 		{
 			name: '/chronicle',
 			summary: 'One-time codebase bootstrapping.',
@@ -45,22 +63,7 @@
 		{
 			name: '/red-book',
 			summary: 'Post-PR convention capture.',
-			details: 'After a PR review, extracts conventions from reviewer comments and adds them to CLAUDE.md. Closes the convention learning loop \u2014 reviewer feedback becomes documented patterns that future quests will follow.'
-		},
-		{
-			name: '/retro',
-			summary: 'Post-fellowship retrospective analysis.',
-			details: 'Analyzes a completed fellowship\u2019s gate history, palantir alerts, and quest metrics to surface patterns. Identifies which gates added value, which phases caused delays, and interactively recommends configuration changes like auto-approving gates with zero rejection rates.'
-		},
-		{
-			name: '/missive',
-			summary: 'Fetch GitHub issue context for quest spawning.',
-			details: 'Pulls structured context from GitHub issues via gh CLI \u2014 title, body, labels, and recent comments. Returns a package with issue context, a suggested branch name incorporating the issue number, and PR closing keywords (Closes #N). Gandalf invokes it automatically when issue references (#N) are detected in quest descriptions. Also usable standalone: /missive 42 to preview what context a quest would receive.'
-		},
-		{
-			name: '/lorebook',
-			summary: 'Load phase-specific guidance from a quest template.',
-			details: 'Invoked at the start of each quest phase when your spawn prompt includes a TEMPLATE: assignment. Resolves the template file from project (.claude/fellowship-templates/) or user (~/.claude/fellowship-templates/) directories, reads the section matching the current phase, and applies the guidance as advisory context. Created via /scribe.'
+			details: 'After a PR review, extracts conventions from reviewer comments and adds them to CLAUDE.md. Closes the convention learning loop — reviewer feedback becomes documented patterns that future quests will follow.'
 		},
 		{
 			name: '/settings',
@@ -70,7 +73,7 @@
 		{
 			name: '/scribe',
 			summary: 'Create reusable quest templates from codebase conventions.',
-			details: 'Analyzes your project to create quest templates that encode project-specific knowledge — conventions Claude wouldn\u2019t know, domain rules that aren\u2019t in code, team workflows that matter. Templates provide phase-specific guidance loaded automatically by /lorebook during quests. Stored in .claude/fellowship-templates/ (project) or ~/.claude/fellowship-templates/ (personal).'
+			details: 'Analyzes your project to create quest templates that encode project-specific knowledge — conventions Claude wouldn’t know, domain rules that aren’t in code, team workflows that matter. Templates provide phase-specific guidance loaded automatically by /lorebook during quests. Stored in .claude/fellowship-templates/ (project) or ~/.claude/fellowship-templates/ (personal).'
 		},
 		{
 			name: '/guide',
@@ -81,26 +84,47 @@
 			name: '/rekindle',
 			summary: 'Recover a fellowship after a session crash.',
 			details: 'Scans worktrees and state files to reconstruct fellowship state from on-disk artifacts. Presents a recovery dashboard showing which quests are resumable (have checkpoints), stale (no checkpoint), or already complete (branch merged). On confirmation, re-spawns Gandalf and quest runners with recovered context.'
-		},
+		}
 	];
 </script>
 
 <svelte:head>
-	<title>Skills | Fellowship</title>
-	<meta name="description" content="Fellowship slash commands that orchestrate different parts of the workflow." />
+	<title>Skills & Commands | Fellowship</title>
+	<meta name="description" content="Fellowship skills and commands that orchestrate different parts of the workflow." />
 </svelte:head>
 
 <div class="container page">
-	<h1>Skills</h1>
+	<h1>Skills & Commands</h1>
 	<p class="intro">
-		Fellowship skills are slash commands that orchestrate different parts of the workflow.
-		Each skill is a structured prompt — no runtime code.
+		Fellowship ships two kinds of slash-typeable prompts. <strong>Skills</strong> are invoked automatically
+		by Claude at the right moment in a workflow — you can also run them directly with their name.
+		<strong>Commands</strong> only run when you type them yourself; Claude never invokes them on its own.
+		Each is a structured prompt — no runtime code.
 	</p>
 
 	<div class="divider"><span class="divider-ring"></span></div>
 
+	<h2 class="group-heading">Skills (auto-invoked)</h2>
+	<p class="group-intro">Loaded automatically by Claude as part of a quest, fellowship, or scout workflow.</p>
+
 	<div class="skills-list">
 		{#each skills as skill, i (skill.name)}
+			<details class="skill-card animate-in" style="animation-delay: {i * 100}ms">
+				<summary>
+					<span class="chevron" aria-hidden="true"></span>
+					<code class="skill-name">{skill.name}</code>
+					<span class="skill-summary">{skill.summary}</span>
+				</summary>
+				<p class="skill-details">{skill.details}</p>
+			</details>
+		{/each}
+	</div>
+
+	<h2 class="group-heading">Commands (user-invoked)</h2>
+	<p class="group-intro">Run only when you type them — no automatic invocation, no base context cost.</p>
+
+	<div class="skills-list">
+		{#each commands as skill, i (skill.name)}
 			<details class="skill-card animate-in" style="animation-delay: {i * 100}ms">
 				<summary>
 					<span class="chevron" aria-hidden="true"></span>
@@ -128,6 +152,18 @@
 		color: var(--color-text-secondary);
 		max-width: 42em;
 		line-height: 1.7;
+	}
+
+	.group-heading {
+		margin-top: var(--space-xl);
+		margin-bottom: var(--space-xs);
+	}
+
+	.group-intro {
+		color: var(--color-text-secondary);
+		max-width: 42em;
+		line-height: 1.6;
+		margin-bottom: var(--space-md);
 	}
 
 	.skills-list {

--- a/site/src/routes/skills/+page.svelte
+++ b/site/src/routes/skills/+page.svelte
@@ -5,7 +5,7 @@
 		{
 			name: '/quest',
 			summary: 'Full Research → Plan → Implement lifecycle for non-trivial tasks.',
-			details: 'The hub skill that orchestrates everything. Takes a task description, creates an isolated worktree, and walks through six phases: Onboard, Research, Plan, Implement, Review, Complete. In standard mode, each phase has a hard gate requiring approval before proceeding. Uses /council for context, /gather-lore for conventions, /lembas for context compression between phases, and /warden for pre-PR review. Supports plan-driven mode: provide a pre-existing plan file and the quest skips Research and Plan, jumping straight to Implement. Supports promoted mode: when a quest is promoted from a scout, Phase 1 enters validation mode — verifying and supplementing scout findings instead of researching from scratch. Includes a bulletin board for cross-quest knowledge sharing: quests scan the bulletin at Research start and post discoveries during Research and Implement. The bulletin is shared across all worktrees via the main repo root.'
+			details: 'The hub skill that orchestrates everything. Takes a task description, creates an isolated worktree, and walks through seven phases: Onboard, Research, Plan, Implement, Adversarial (a balrog agent attacks the implementation), Review, Complete. In standard mode, each phase has a hard gate requiring approval before proceeding. Uses /council for context, /gather-lore for conventions, /lembas for context compression between phases, and /warden for pre-PR review. Supports plan-driven mode: provide a pre-existing plan file and the quest skips Research and Plan, jumping straight to Implement. Supports promoted mode: when a quest is promoted from a scout, Phase 1 enters validation mode — verifying and supplementing scout findings instead of researching from scratch. Includes a bulletin board for cross-quest knowledge sharing: quests scan the bulletin at Research start and post discoveries during Research and Implement. The bulletin is shared across all worktrees via the main repo root.'
 		},
 		{
 			name: '/fellowship',
@@ -30,7 +30,7 @@
 		{
 			name: '/lembas',
 			summary: 'Context compression between phases.',
-			details: 'Compacts the conversation context at phase transitions. Keeps the context window in the reasoning sweet spot by summarizing what’s been done and what needs to happen next. Invoked automatically at all four phase transitions during a quest.'
+			details: 'Compacts the conversation context at phase transitions. Keeps the context window in the reasoning sweet spot by summarizing what’s been done and what needs to happen next. Invoked automatically at every phase transition during a quest.'
 		},
 		{
 			name: '/warden',


### PR DESCRIPTION
## Summary

Four slices from a full architecture review of the plugin's skills, agents, commands, and docs:

**1. Followability bug fixes (`bc16dc6`)**
- balrog is instructed to write test cases but had no file-creation tool — grants `Write`/`Edit`
- Corrects legacy "Task tool" subagent-spawn references to the Agent tool (Task* tools are task-tracking and have no `subagent_type` param) in council, quest, and fellowship
- lead-behavior's DOT decision graph now includes the mandatory gate-count verification its own Gate Tracking prose requires
- Fixes quest resume-mode list numbering (skipped step 3); adds an explicit fallback when `superpowers`/`pr-review-toolkit` skills aren't installed
- Replaces soft, rationalizable triggers ("feels bloated", findings "that matter", "one question") with concrete criteria

**2. Model routing (`6d1e0a6`)**
- Every subagent spawn previously inherited the lead session's model; now each role routes to a cost-appropriate tier
- palantir → `haiku` frontmatter default (read-only monitoring); scout → `sonnet` (research)
- Explore scans in quest/scout/council → haiku; scout's validator → sonnet
- Quest teammates and balrog deliberately stay on inherit — code-writing and adversarial review are not downgraded by default
- New `models.*` block in `fellowship.json` (six keys, documented in `/settings`) overrides any default via the Agent tool's per-invocation `model` param, which takes precedence over frontmatter

**3. Spawn-prompt dedup + protocol reconciliation (`fd24caf`)**
- Collapses the three ~90%-identical quest spawn prompts (standard/plan-driven/promoted) into one base template plus per-variant placeholder tables; the plan-driven variant's drifted, weaker hold/shutdown language is unified to the full standard text
- `_protocol.md` becomes the canonical messaging spec (documents both recipient cases) and states the self-containment rule; agents embed marked, consistent inline copies
- Fixes balrog's runtime-broken instruction to read `plugin/agents/_protocol.md` — that path doesn't resolve from a user project for installed plugins
- Marks the intentionally-mirrored gather-lore/warden pattern taxonomy with keep-in-sync comments

**4. Docs refresh (`2812954`)**
- README Skills table now lists the 10 real skills (adds missive, retro, lorebook), commands get their own table (adds previously undocumented rekindle, scribe, guide), Agents expands to all 4 (adds balrog, scout)
- Site skills page groups cards into auto-invoked Skills vs user-invoked Commands, per the distinction plugin/CLAUDE.md draws
- Config docs (README + site) gain `models.*` and the previously undocumented `issues.autoClose`

## Test plan

- [x] Site builds cleanly (`npm run build` in `site/`)
- [x] No stray "Task tool" spawn references remain in `plugin/`
- [x] Docs tables verified against actual `plugin/skills|commands|agents/` contents

Changelog/version bump intentionally deferred to the `/release` flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgmPGMY1zBQSNGs7LERBVe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable models for quest, scout, Palantir, Balrog, Explore, and validator workflows.
  * Added issue auto-close settings and a read-only Validator agent.
  * Added an Adversarial workflow phase and expanded commands including `/missive`, `/retro`, `/lorebook`, `/guide`, `/rekindle`, and `/scribe`.
  * Improved agent coordination, validation, shutdown handling, and task recovery.
* **Documentation**
  * Updated configuration, agent, workflow, and command references.
  * Clarified configuration inheritance, dependency fallbacks, context management, and command classifications.
  * Added progress tracking guidance for held work and expanded phase transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Post-review additions

- **Review-feedback fixes** (`52105eb`, `4b0ae1d`): mode-aware gate accounting, models.* valid values corrected, SendMessage recipient-by-name, new read-only `validator` agent, project config layer loading, worktree-path publication, hidden sync-directive removal — see the review disposition comments below.
- **Folded follow-ups** (`b7323e8`, `e2e1485`): CLI phase validation now derives from `state.phaseOrder` (Adversarial was rejected by `fellowship init` and ranked 0 in company progress), and `/validate-docs` gained a config-schema cross-check (settings.md ↔ README ↔ site). Replaces closed #92/#93.
