### PR TITLE
fix(cli): derive valid phases from state.phaseOrder (Adversarial was missing)

### DIFF
--- a/cli/cmd/fellowship/main.go
+++ b/cli/cmd/fellowship/main.go
@@ -807,12 +807,8 @@ func runInit(d *db.DB) int {
 	initDir := fs.String("dir", "", "Worktree or repo root (default: auto-detect via git)")
 	fs.Parse(os.Args[2:])
 
-	validPhases := map[string]bool{
-		"Onboard": true, "Research": true, "Plan": true,
-		"Implement": true, "Review": true, "Complete": true,
-	}
-	if *phase != "" && !validPhases[*phase] {
-		fmt.Fprintf(os.Stderr, "fellowship: invalid phase %q\n", *phase)
+	if *phase != "" && !state.IsValidPhase(*phase) {
+		fmt.Fprintf(os.Stderr, "fellowship: invalid phase %q (valid: %s)\n", *phase, strings.Join(state.Phases(), ", "))
 		return 1
 	}
 

--- a/cli/internal/company/company.go
+++ b/cli/internal/company/company.go
@@ -25,15 +25,15 @@ type CompanyProgress struct {
 	Pending    int    `json:"pending_gates"` // quests with gate_pending
 }
 
-// phaseRank maps phases to a numeric rank for progress tracking.
-var phaseRank = map[string]int{
-	"Onboard":   0,
-	"Research":  1,
-	"Plan":      2,
-	"Implement": 3,
-	"Review":    4,
-	"Complete":  5,
-}
+// phaseRank maps phases to a numeric rank for progress tracking,
+// derived from the canonical phase order in the state package.
+var phaseRank = func() map[string]int {
+	m := make(map[string]int)
+	for i, p := range state.Phases() {
+		m[p] = i
+	}
+	return m
+}()
 
 // CalculateProgress computes aggregate progress for a company given quest statuses.
 func CalculateProgress(company dashboard.CompanyEntry, quests []dashboard.QuestStatus) CompanyProgress {
@@ -55,7 +55,7 @@ func CalculateProgress(company dashboard.CompanyEntry, quests []dashboard.QuestS
 		if qs.Phase == "Complete" {
 			progress.Completed++
 		}
-		if rank, ok := phaseRank[qs.Phase]; ok && rank >= 3 { // Implement+
+		if rank, ok := phaseRank[qs.Phase]; ok && rank >= phaseRank["Implement"] {
 			progress.InProgress++
 		}
 		if qs.GatePending {

--- a/cli/internal/state/state.go
+++ b/cli/internal/state/state.go
@@ -45,6 +45,23 @@ func IsEarlyPhase(phase string) bool {
 	return phase == "Onboard" || phase == "Research" || phase == "Plan"
 }
 
+// Phases returns the ordered quest phase names.
+func Phases() []string {
+	out := make([]string, len(phaseOrder))
+	copy(out, phaseOrder)
+	return out
+}
+
+// IsValidPhase reports whether p is a known quest phase.
+func IsValidPhase(p string) bool {
+	for _, phase := range phaseOrder {
+		if phase == p {
+			return true
+		}
+	}
+	return false
+}
+
 // Load reads quest state from DB by quest name.
 func Load(conn *sqlite.Conn, questName string) (*State, error) {
 	var s State

--- a/cli/internal/state/state_test.go
+++ b/cli/internal/state/state_test.go
@@ -128,6 +128,19 @@ func TestNextPhase(t *testing.T) {
 	}
 }
 
+func TestIsValidPhase(t *testing.T) {
+	for _, p := range []string{"Onboard", "Research", "Plan", "Implement", "Adversarial", "Review", "Complete"} {
+		if !state.IsValidPhase(p) {
+			t.Errorf("IsValidPhase(%q) = false, want true", p)
+		}
+	}
+	for _, p := range []string{"", "onboard", "InvalidPhase", "Done"} {
+		if state.IsValidPhase(p) {
+			t.Errorf("IsValidPhase(%q) = true, want false", p)
+		}
+	}
+}
+
 func TestIsEarlyPhase(t *testing.T) {
 	early := []string{"Onboard", "Research", "Plan"}
 	late := []string{"Implement", "Adversarial", "Review", "Complete"}


### PR DESCRIPTION
## Summary

Two hardcoded phase lists in the CLI omitted `Adversarial` even though `state.phaseOrder` includes it:

- `fellowship init --phase Adversarial` was rejected as an invalid phase (`cli/cmd/fellowship/main.go`)
- Company progress ranked Adversarial-phase quests as rank 0 via a missing map key, understating progress and excluding them from the Implement+ count (`cli/internal/company/company.go`)

Fix: export `state.Phases()` and `state.IsValidPhase()` and derive both call sites from them, giving the phase list a single source of truth. The Implement+ threshold now references `phaseRank["Implement"]` instead of a magic `3`, and the init error message lists the valid phases.

Found during PR #91's code review — pre-existing bug outside that diff, split out per branch-per-issue convention.

## Test plan

- [x] New `TestIsValidPhase` covering all seven phases + rejections
- [x] `gofmt -l` clean, `go vet ./...` clean, `go test ./...` all packages pass (Go 1.25 container)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgmPGMY1zBQSNGs7LERBVe